### PR TITLE
feat(ui): banner offline y indicador de red ampliado (T-07D.1 + T-07D.2)

### DIFF
--- a/apps/renderer/src/components/layout/AppShell.tsx
+++ b/apps/renderer/src/components/layout/AppShell.tsx
@@ -1,21 +1,33 @@
 import { Outlet } from 'react-router-dom';
-import { Sidebar } from './Sidebar';
-import { Topbar }  from './Topbar';
-import { BottomNav } from './BottomNav';
+import { Sidebar }          from './Sidebar';
+import { Topbar }           from './Topbar';
+import { BottomNav }        from './BottomNav';
+import { OfflineBanner }    from './OfflineBanner';
+import { useNetworkStatus } from '../../hooks/useNetworkStatus';
 
 export function AppShell() {
+  const { isOffline, isChecking, syncState } = useNetworkStatus();
+
+  // Solo mostrar banner cuando está CONFIRMADAMENTE offline, no durante "checking"
+  const showBanner = isOffline && !isChecking;
+
   return (
     <div style={{
       display: 'flex', height: '100vh',
       background: 'var(--bg-base)', overflow: 'hidden',
     }}>
-      {/* Sidebar — visible solo en desktop */}
       <div className="sidebar-wrapper">
         <Sidebar />
       </div>
 
-      <div style={{ display: 'flex', flexDirection: 'column', flex: 1, minWidth: 0, overflow: 'hidden' }}>
+      <div style={{
+        display: 'flex', flexDirection: 'column',
+        flex: 1, minWidth: 0, overflow: 'hidden',
+      }}>
+        {showBanner && <OfflineBanner syncState={syncState} />}
+
         <Topbar />
+
         <main style={{
           flex: 1, overflowY: 'auto',
           padding: 'clamp(16px, 3vw, 28px)',
@@ -25,8 +37,7 @@ export function AppShell() {
         </main>
       </div>
 
-      {/* Bottom Nav — visible solo en móvil */}
       <BottomNav />
     </div>
   );
-}
+}   

--- a/apps/renderer/src/components/layout/OfflineBanner.tsx
+++ b/apps/renderer/src/components/layout/OfflineBanner.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useState } from 'react';
+import { SyncState } from '../../hooks/useNetworkStatus';
+
+interface Props {
+  syncState: SyncState;
+}
+
+export function OfflineBanner({ syncState }: Props) {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setVisible(true), 800);
+    return () => clearTimeout(timer);
+  }, []);
+
+  if (!visible) return null;
+
+  const pendientes = syncState.pendientes ?? 0;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      style={{
+        width:          '100%',
+        flexShrink:     0,
+        display:        'flex',
+        alignItems:     'center',
+        justifyContent: 'center',
+        gap:            '8px',
+        background:     'var(--warning)',
+        color:          '#fff',
+        padding:        '7px 16px',
+        fontSize:       '13px',
+        fontWeight:     600,
+        boxShadow:      '0 2px 8px rgba(0,0,0,0.3)',
+        animation:      'slideDown 0.25s ease',
+      }}
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="15" height="15"
+        viewBox="0 0 24 24"
+        fill="none" stroke="currentColor"
+        strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"
+        aria-hidden="true"
+        style={{ flexShrink: 0 }}
+      >
+        <line x1="2" y1="2" x2="22" y2="22" />
+        <path d="M8.5 16.5a5 5 0 0 1 7 0" />
+        <path d="M2 8.82a15 15 0 0 1 4.17-2.65" />
+        <path d="M10.66 5c4.01-.36 8.14.9 11.34 3.76" />
+        <path d="M16.85 11.25a10 10 0 0 1 2.22 1.68" />
+        <path d="M5 12.5A10 10 0 0 1 10.5 10" />
+        <circle cx="12" cy="20" r="1" />
+      </svg>
+
+      <span>Modo sin conexión</span>
+      <span style={{ opacity: 0.6 }}>•</span>
+
+      {pendientes > 0 ? (
+        <span>
+          {pendientes === 1
+            ? '1 operación pendiente de sincronizar'
+            : `${pendientes} operaciones pendientes de sincronizar`}
+        </span>
+      ) : (
+        <span style={{ opacity: 0.85, fontWeight: 400 }}>
+          Sin operaciones pendientes
+        </span>
+      )}
+    </div>
+  );
+}

--- a/apps/renderer/src/components/layout/Topbar.tsx
+++ b/apps/renderer/src/components/layout/Topbar.tsx
@@ -1,9 +1,10 @@
 /**
  * Topbar.tsx
  * T-07.3: Muestra indicador de conectividad en tiempo real
- * Muestra badge de pendientes de sync cuando hay registros sin subir
+ * T-07D.2: Badge naranja cuando hay pendientes + confirmación verde post-sync
  */
 import { useNavigate } from 'react-router-dom';
+import { useEffect, useRef, useState } from 'react';
 import { useAuthStore } from '../../store/authStore';
 import { useThemeStore } from '../../store/themeStore';
 import { useNetworkStatus } from '../../hooks/useNetworkStatus';
@@ -13,6 +14,29 @@ export function Topbar() {
   const { usuario, logout } = useAuthStore();
   const { isDark, toggleTheme } = useThemeStore();
   const { status, isOnline, syncState } = useNetworkStatus();
+
+  // ── Lógica de confirmación post-sync ──────────────────────
+  const [showSynced, setShowSynced] = useState(false);
+  const prevPendientes = useRef<number>(syncState.pendientes);
+  const syncTimer      = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    const prev = prevPendientes.current;
+    const curr = syncState.pendientes;
+
+    // Si había pendientes y ahora no hay → sync completada
+    if (prev > 0 && curr === 0 && isOnline) {
+      setShowSynced(true);
+      if (syncTimer.current) clearTimeout(syncTimer.current);
+      syncTimer.current = setTimeout(() => setShowSynced(false), 3000);
+    }
+
+    prevPendientes.current = curr;
+
+    return () => {
+      if (syncTimer.current) clearTimeout(syncTimer.current);
+    };
+  }, [syncState.pendientes, isOnline]);
 
   function handleLogout() { logout(); navigate('/login'); }
 
@@ -42,22 +66,49 @@ export function Topbar() {
       </div>
     );
 
+    // Confirmación verde post-sync (3 segundos)
+    if (showSynced) return (
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: '5px',
+        padding: '4px 10px', background: 'rgba(16,185,129,0.15)',
+        border: '1px solid rgba(16,185,129,0.4)', borderRadius: '20px',
+        animation: 'pulse 0.4s ease',
+      }}>
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none"
+          stroke="var(--success)" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+          <polyline points="20 6 9 17 4 12" />
+        </svg>
+        <span style={{ fontSize: '11px', fontWeight: 600, color: 'var(--success)' }}>
+          Sincronizado
+        </span>
+      </div>
+    );
+
+    // Online + pendientes → badge naranja separado
+    if (syncState.pendientes > 0) return (
+      <div style={{ display: 'flex', alignItems: 'center', gap: '5px',
+        padding: '4px 10px', background: 'rgba(245,158,11,0.1)',
+        border: '1px solid rgba(245,158,11,0.35)', borderRadius: '20px' }}>
+        <div style={{ width: '7px', height: '7px', borderRadius: '50%', background: 'var(--warning)', animation: 'pulse 1.5s infinite' }} />
+        <span style={{ fontSize: '11px', fontWeight: 600, color: 'var(--warning)' }}>En línea</span>
+        <span style={{ fontSize: '10px', color: 'var(--warning)', fontWeight: 700 }}>
+          · {syncState.pendientes} por sincronizar
+        </span>
+        {syncState.errores > 0 && (
+          <span style={{ fontSize: '10px', color: 'var(--danger)', fontWeight: 700 }}>
+            · {syncState.errores} errores
+          </span>
+        )}
+      </div>
+    );
+
+    // Online sin pendientes — estado normal
     return (
       <div style={{ display: 'flex', alignItems: 'center', gap: '5px',
         padding: '4px 10px', background: 'rgba(16,185,129,0.08)',
         border: '1px solid rgba(16,185,129,0.2)', borderRadius: '20px' }}>
         <div style={{ width: '7px', height: '7px', borderRadius: '50%', background: 'var(--success)' }} />
         <span style={{ fontSize: '11px', fontWeight: 500, color: 'var(--success)' }}>En línea</span>
-        {syncState.pendientes > 0 && (
-          <span style={{ fontSize: '10px', color: 'var(--warning)', fontWeight: 700 }}>
-            · {syncState.pendientes} por sincronizar
-          </span>
-        )}
-        {syncState.errores > 0 && (
-          <span style={{ fontSize: '10px', color: 'var(--danger)', fontWeight: 700 }}>
-            · {syncState.errores} errores
-          </span>
-        )}
       </div>
     );
   };

--- a/apps/renderer/src/hooks/useNetworkStatus.ts
+++ b/apps/renderer/src/hooks/useNetworkStatus.ts
@@ -10,15 +10,16 @@ import { api } from '../services/api.client';
 
 export type NetworkStatus = 'online' | 'offline' | 'checking';
 
-interface SyncState {
-  pendientes: number;
-  errores:    number;
-  lastSync:   Date | null;
+export interface SyncState {
+  pendientes:    number;
+  sincronizados: number;
+  errores:       number;
+  lastSync:      Date | null;
 }
 
 export function useNetworkStatus() {
   const [status,    setStatus]    = useState<NetworkStatus>('checking');
-  const [syncState, setSyncState] = useState<SyncState>({ pendientes: 0, errores: 0, lastSync: null });
+  const [syncState, setSyncState] = useState<SyncState>({ pendientes: 0, sincronizados: 0, errores: 0, lastSync: null });
   const pingTimer = useRef<ReturnType<typeof setInterval> | null>(null);
 
   // Ping real al servidor
@@ -35,7 +36,7 @@ export function useNetworkStatus() {
   const fetchSyncState = useCallback(async () => {
     try {
       const { data } = await api.get('/inventario/sync-pendientes', { timeout: 4000 });
-      setSyncState({ pendientes: data.pendientes, errores: data.errores, lastSync: new Date() });
+      setSyncState({ pendientes: data.pendientes, sincronizados: data.sincronizados ?? 0, errores: data.errores, lastSync: new Date() });
     } catch {
       // Si falla, no actualizar
     }


### PR DESCRIPTION
Implementa el indicador visual de modo offline y contador de operaciones pendientes en la barra superior.

T-07D.1: Banner fijo en la parte superior cuando no hay conexión, muestra cantidad de operaciones pendientes de sincronizar. Se oculta al recuperar la conexión.

T-07D.2: Indicador de red en Topbar ampliado con 5 estados: verificando, sin conexión, pendientes en naranja con conteo, confirmación verde "Sincronizado" por 3 segundos, y en línea normal.