### PR TITLE
fix(deploy): corregir build de Railway con Railpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "ferred-app",
   "version": "2.4.0",
   "private": true,
+  "packageManager": "pnpm@9.15.4",
   "scripts": {
     "dev": "pnpm --filter renderer dev",
     "dev:server": "pnpm --filter server dev",

--- a/railway.toml
+++ b/railway.toml
@@ -1,6 +1,7 @@
 [build]
 builder = "NIXPACKS"
-buildCommand = "npm install -g pnpm@9 && pnpm install && cd apps/server && npx prisma generate && cd ../.. && pnpm --filter server build"
+installCommand = "npm install -g pnpm@9 && pnpm install"
+buildCommand = "cd apps/server && npx prisma generate && cd ../.. && pnpm --filter server build"
 
 [deploy]
 startCommand = "node apps/server/dist/index.js"


### PR DESCRIPTION
Railpack ejecuta npm ci por defecto y falla porque no hay package-lock.json. Agregar packageManager en package.json para que detecte pnpm, y separar installCommand del buildCommand en railway.toml.