### PR TITLE
feat: agregar updated_at para sincronizacion incremental offline

### DIFF
--- a/apps/server/prisma/migrations/20260428201500_t07e2_updated_at_delta_sync/migration.sql
+++ b/apps/server/prisma/migrations/20260428201500_t07e2_updated_at_delta_sync/migration.sql
@@ -1,0 +1,14 @@
+-- T-07E.2: columnas updated_at para sincronizacion incremental por delta.
+
+ALTER TABLE "categorias"
+ADD COLUMN "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+ALTER TABLE "productos"
+ADD COLUMN "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+ALTER TABLE "stock_sucursal"
+ADD COLUMN "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+UPDATE "stock_sucursal"
+SET "updated_at" = "actualizado_en"
+WHERE "actualizado_en" IS NOT NULL;

--- a/apps/server/prisma/schema.prisma
+++ b/apps/server/prisma/schema.prisma
@@ -27,6 +27,7 @@ model Categoria {
   nombre      String @unique
   descripcion String?
   activo      Boolean @default(true)
+  updatedAt   DateTime @default(now()) @updatedAt @map("updated_at")
   productos   Producto[]
   @@map("categorias")
 }
@@ -62,6 +63,7 @@ model Producto {
   stockMinimo        Int      @default(0) @map("stock_minimo")
   activo             Boolean  @default(true)
   creadoEn           DateTime @default(now()) @map("creado_en")
+  updatedAt          DateTime @default(now()) @updatedAt @map("updated_at")
   categoria          Categoria?    @relation(fields: [categoriaId], references: [id])
   detallesVenta      DetalleVenta[]
   stocks             StockSucursal[]
@@ -76,6 +78,7 @@ model StockSucursal {
   cantidad      Int      @default(0)
   minimo        Int      @default(0)
   actualizadoEn DateTime @default(now()) @updatedAt @map("actualizado_en")
+  updatedAt     DateTime @default(now()) @updatedAt @map("updated_at")
   producto      Producto  @relation(fields: [productoId], references: [id])
   sucursal      Sucursal  @relation(fields: [sucursalId], references: [id])
   @@unique([productoId, sucursalId])

--- a/apps/server/src/adapters/db/sqlite/sqlite.client.ts
+++ b/apps/server/src/adapters/db/sqlite/sqlite.client.ts
@@ -17,6 +17,7 @@
 
     const schema = readSchema();
     _db.exec(schema);
+    ensureUpdatedAtColumns(_db);
 
     return _db;
   }
@@ -541,6 +542,71 @@
     return SQLITE_SCHEMA;
   }
 
+  function ensureUpdatedAtColumns(db: Database.Database) {
+    ensureColumn(db, 'categorias', 'updated_at', 'TEXT');
+    ensureColumn(db, 'productos', 'updated_at', 'TEXT');
+    ensureColumn(db, 'stock_sucursal', 'updated_at', 'TEXT');
+
+    db.prepare(`
+      UPDATE categorias
+      SET updated_at = datetime('now')
+      WHERE updated_at IS NULL
+    `).run();
+
+    db.prepare(`
+      UPDATE productos
+      SET updated_at = COALESCE(creado_en, datetime('now'))
+      WHERE updated_at IS NULL
+    `).run();
+
+    db.prepare(`
+      UPDATE stock_sucursal
+      SET updated_at = COALESCE(actualizado_en, datetime('now'))
+      WHERE updated_at IS NULL
+    `).run();
+
+    db.exec(`
+      CREATE TRIGGER IF NOT EXISTS categorias_touch_updated_at
+      AFTER UPDATE ON categorias
+      FOR EACH ROW
+      WHEN NEW.updated_at = OLD.updated_at
+      BEGIN
+        UPDATE categorias SET updated_at = datetime('now') WHERE id = OLD.id;
+      END;
+
+      CREATE TRIGGER IF NOT EXISTS productos_touch_updated_at
+      AFTER UPDATE ON productos
+      FOR EACH ROW
+      WHEN NEW.updated_at = OLD.updated_at
+      BEGIN
+        UPDATE productos SET updated_at = datetime('now') WHERE id = OLD.id;
+      END;
+
+      CREATE TRIGGER IF NOT EXISTS stock_sucursal_touch_updated_at
+      AFTER UPDATE ON stock_sucursal
+      FOR EACH ROW
+      WHEN NEW.updated_at = OLD.updated_at
+      BEGIN
+        UPDATE stock_sucursal
+        SET updated_at = datetime('now'),
+            actualizado_en = datetime('now')
+        WHERE id = OLD.id;
+      END;
+    `);
+  }
+
+  function ensureColumn(
+    db: Database.Database,
+    table: string,
+    column: string,
+    definition: string
+  ) {
+    const columns = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;
+    if (columns.some((item) => item.name === column)) return;
+
+    db.prepare(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition}`).run();
+  }
+
   function logPendienteSqlite(
     tabla: string,
     operacion: 'CREATE' | 'UPDATE' | 'DELETE',
@@ -600,7 +666,8 @@
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     nombre TEXT NOT NULL UNIQUE,
     descripcion TEXT,
-    activo INTEGER NOT NULL DEFAULT 1
+    activo INTEGER NOT NULL DEFAULT 1,
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
   );
 
   CREATE TABLE IF NOT EXISTS usuarios (
@@ -628,7 +695,8 @@
     stock_actual INTEGER NOT NULL DEFAULT 0,
     stock_minimo INTEGER NOT NULL DEFAULT 0,
     activo INTEGER NOT NULL DEFAULT 1,
-    creado_en TEXT NOT NULL DEFAULT (datetime('now'))
+    creado_en TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
   );
 
   CREATE TABLE IF NOT EXISTS stock_sucursal (
@@ -638,6 +706,7 @@
     cantidad INTEGER NOT NULL DEFAULT 0,
     minimo INTEGER NOT NULL DEFAULT 0,
     actualizado_en TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
     UNIQUE(producto_id, sucursal_id)
   );
 

--- a/apps/server/src/adapters/db/sqlite/sqlite.schema.sql
+++ b/apps/server/src/adapters/db/sqlite/sqlite.schema.sql
@@ -11,7 +11,8 @@ CREATE TABLE IF NOT EXISTS categorias (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   nombre TEXT NOT NULL UNIQUE,
   descripcion TEXT,
-  activo INTEGER NOT NULL DEFAULT 1
+  activo INTEGER NOT NULL DEFAULT 1,
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
 CREATE TABLE IF NOT EXISTS usuarios (
@@ -39,7 +40,8 @@ CREATE TABLE IF NOT EXISTS productos (
   stock_actual INTEGER NOT NULL DEFAULT 0,
   stock_minimo INTEGER NOT NULL DEFAULT 0,
   activo INTEGER NOT NULL DEFAULT 1,
-  creado_en TEXT NOT NULL DEFAULT (datetime('now'))
+  creado_en TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
 CREATE TABLE IF NOT EXISTS stock_sucursal (
@@ -49,6 +51,7 @@ CREATE TABLE IF NOT EXISTS stock_sucursal (
   cantidad INTEGER NOT NULL DEFAULT 0,
   minimo INTEGER NOT NULL DEFAULT 0,
   actualizado_en TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
   UNIQUE(producto_id, sucursal_id)
 );
 

--- a/apps/server/src/adapters/sync/sync.service.ts
+++ b/apps/server/src/adapters/sync/sync.service.ts
@@ -109,11 +109,12 @@ const CAMPOS_ESCALARES: Record<string, string[]> = {
     'stockMinimo',
     'activo',
     'creadoEn',
+    'updatedAt',
   ],
-  categoria: ['id', 'nombre', 'descripcion', 'activo'],
+  categoria: ['id', 'nombre', 'descripcion', 'activo', 'updatedAt'],
   // BUG-A03: eliminado 'passwordHash' — el campo correcto en Prisma es 'contrasenaHash'
   usuario: ['id', 'nombre', 'email', 'contrasenaHash', 'rol', 'sucursalId', 'activo'],
-  stockSucursal: ['id', 'productoId', 'sucursalId', 'cantidad', 'minimo', 'actualizadoEn'],
+  stockSucursal: ['id', 'productoId', 'sucursalId', 'cantidad', 'minimo', 'actualizadoEn', 'updatedAt'],
   facturaDte: [
     'id',
     'sucursalId',


### PR DESCRIPTION
## Resumen
- Agrega updated_at a categorias, productos y stock_sucursal.
- Añade migración Prisma para sincronización incremental por delta.
- Actualiza el schema SQLite local.
- Agrega compatibilidad para bases SQLite existentes.
- Incluye updatedAt en el whitelist de SyncService.

## Validación
- prisma validate
- prisma generate
- tsc --noEmit --module ES2022
- git diff --check