### PR TITLE
fix(bugs-deuda-tecnica-v3): BUG-M01, DT-13, DT-17/BUG-C06, DT-21

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,49 @@
+# ── Entorno ──────────────────────────────────────────────────
+NODE_ENV=development
+PORT=3001
+
+# ── Multi-sucursal ────────────────────────────────────────────
+# Cada instalación de Electron usa un BRANCH_ID distinto.
+# El SQLite local se guardará en: data/ferred_branch<BRANCH_ID>.db
+BRANCH_ID=1
+
+# ── Supabase / Postgres ───────────────────────────────────────
+# URL del proyecto en Supabase (panel → Settings → API)
+SUPABASE_URL=https://<proyecto>.supabase.co
+SUPABASE_ANON_KEY=<anon-public-key>
+# Clave de servicio con privilegios completos — NUNCA exponer en el cliente
+SUPABASE_SERVICE_KEY=<service-role-key>
+
+# Conexión Prisma: usa pgBouncer (puerto 6543) para queries normales
+DATABASE_URL=postgresql://<usuario>:<password>@<host>:6543/<db>?pgbouncer=true
+# Conexión directa (puerto 5432) para migraciones Prisma
+DIRECT_URL=postgresql://<usuario>:<password>@<host>:5432/<db>
+
+# ── Auth ──────────────────────────────────────────────────────
+# Mínimo 32 caracteres aleatorios; rotar si se filtra
+JWT_SECRET=<min-32-chars-aleatorios>
+JWT_EXPIRES_IN=2h
+
+# Clave para cifrado interno de datos sensibles
+CRYPTO_SECRET=<min-32-chars-aleatorios>
+
+# ── DTE / Hacienda (El Salvador) ──────────────────────────────
+# 'sandbox' para pruebas, 'production' cuando se tengan credenciales reales
+DTE_ENV=sandbox
+DTE_SANDBOX_URL=https://apitest.dtes.mh.gob.sv
+# Credenciales del contribuyente (sandbox o producción)
+# Dejar vacío si no se tienen — la app opera en modo SIMULADO
+DTE_NIT=
+DTE_NRC=
+DTE_NOMBRE_COMERCIAL=
+DTE_AUTH_TOKEN=
+DTE_SANDBOX_USER=
+DTE_SANDBOX_PASS=
+
+# ── SQLite local (opcional) ───────────────────────────────────
+# Electron lo sobrescribe automáticamente con app.getPath('userData')
+# SQLITE_PATH=data/ferred_branch1.db
+
+# ── Auth offline ─────────────────────────────────────────────
+# Días máximos sin sincronizar antes de rechazar login offline (default 30)
+# OFFLINE_AUTH_MAX_DAYS=30

--- a/apps/renderer/src/hooks/useNetworkStatus.ts
+++ b/apps/renderer/src/hooks/useNetworkStatus.ts
@@ -33,7 +33,10 @@ export function useNetworkStatus() {
         baseURL: '',
       });
       setStatus('online');
-    } catch {
+    } catch (err: unknown) {
+      // BUG-M01: loguear para trazabilidad; la UI sigue mostrando modo offline
+      const msg = (err as { message?: string })?.message ?? String(err);
+      console.warn('[useNetworkStatus] ping fallido:', msg);
       setStatus('offline');
     }
   }, []);

--- a/apps/server/prisma/migrations/20260506000000_dt21_sync_log_index/migration.sql
+++ b/apps/server/prisma/migrations/20260506000000_dt21_sync_log_index/migration.sql
@@ -1,0 +1,6 @@
+-- DT-21: índice compuesto en sync_log para acelerar el loop de drenaje offline
+-- pushPendientes() filtra: WHERE status = 'PENDIENTE' (y opcionalmente por tabla)
+-- Sin este índice el loop hace full-scan sobre toda la tabla en cada tick de 30s.
+
+CREATE INDEX IF NOT EXISTS "sync_log_tabla_status_idx"
+ON "sync_log" ("tabla", "status");

--- a/apps/server/prisma/schema.prisma
+++ b/apps/server/prisma/schema.prisma
@@ -130,6 +130,8 @@ model SyncLog {
   creadoEn  DateTime  @default(now()) @map("creado_en")
   sincEn    DateTime? @map("sinc_en")
   usuario   Usuario?  @relation(fields: [usuarioId], references: [id])
+  // DT-21: índice para el loop de drenaje (pushPendientes filtra por status)
+  @@index([tabla, status])
   @@map("sync_log")
 }
 

--- a/apps/server/src/adapters/http/middleware/error.middleware.ts
+++ b/apps/server/src/adapters/http/middleware/error.middleware.ts
@@ -1,11 +1,26 @@
 import { Request, Response, NextFunction } from 'express';
 
+export class AppError extends Error {
+  constructor(
+    public readonly statusCode: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'AppError';
+  }
+}
+
 export function errorMiddleware(
   err: Error,
   _req: Request,
   res: Response,
   _next: NextFunction
 ) {
+  // DT-13: propagar statusCode desde AppError en vez de siempre 500
+  if (err instanceof AppError) {
+    return res.status(err.statusCode).json({ error: err.message });
+  }
+
   console.error('[ERROR]', err.message);
   const isProd = process.env.NODE_ENV === 'production';
   return res.status(500).json({


### PR DESCRIPTION
BUG-M01: useNetworkStatus.checkServer() ya no silencia el error de ping - captura con catch(err) y emite console.warn para trazabilidad mientras la UI sigue transitando a modo offline.
DT-13: error.middleware.ts introduce AppError(statusCode, message); los errores de dominio lanzados con new AppError(400/403/404, ...) ya propagan el código HTTP correcto en vez de siempre 500.
DT-17 / BUG-C06: crea .env.example con todos los keys documentados y valores de ejemplo seguros; ninguna credencial real incluida.
DT-21: agrega @@index([tabla, status]) en SyncLog (schema.prisma) + migración 20260506000000_dt21_sync_log_index para acelerar el loop de drenaje offline que filtra por status='PENDIENTE' en cada tick.