### PR TITLE
feat(T-07E-5): add manual sync indicator

### DIFF
--- a/apps/renderer/src/components/layout/Topbar.tsx
+++ b/apps/renderer/src/components/layout/Topbar.tsx
@@ -13,15 +13,18 @@ export function Topbar() {
   const navigate   = useNavigate();
   const { usuario, logout } = useAuthStore();
   const { isDark, toggleTheme } = useThemeStore();
-  const { status, isOnline, syncState } = useNetworkStatus();
+  const { status, isOnline, syncState, isSyncing, syncError, syncNow } = useNetworkStatus();
   const branchLabel = usuario?.sucursalId
     ? `Sucursal ${usuario.sucursalId}`
     : 'Sin sucursal asignada';
 
   // ── Lógica de confirmación post-sync ──────────────────────
   const [showSynced, setShowSynced] = useState(false);
+  const [syncFeedback, setSyncFeedback] = useState<string | null>(null);
+  const [now, setNow] = useState(() => Date.now());
   const prevPendientes = useRef<number>(syncState.pendientes);
   const syncTimer      = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const feedbackTimer  = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     const prev = prevPendientes.current;
@@ -43,11 +46,68 @@ export function Topbar() {
 
   function handleLogout() { logout(); navigate('/login'); }
 
+  async function handleSyncNow() {
+    try {
+      await syncNow();
+      setSyncFeedback('Sincronizacion completada');
+      setShowSynced(true);
+    } catch {
+      setSyncFeedback('No se pudo sincronizar');
+    }
+
+    if (feedbackTimer.current) clearTimeout(feedbackTimer.current);
+    feedbackTimer.current = setTimeout(() => setSyncFeedback(null), 3500);
+  }
+
+  useEffect(() => {
+    const timer = setInterval(() => setNow(Date.now()), 60_000);
+    return () => {
+      clearInterval(timer);
+      if (feedbackTimer.current) clearTimeout(feedbackTimer.current);
+    };
+  }, []);
+
   const initials = (name: string) =>
     name.trim().split(/\s+/).slice(0, 2).map(p => p[0]?.toUpperCase() ?? '').join('');
 
+  const getLastSyncInfo = () => {
+    if (!isOnline) {
+      return {
+        label: 'Ultima sync: sin conexion',
+        color: 'var(--text-subtle)',
+        background: 'rgba(148,163,184,0.1)',
+        border: 'rgba(148,163,184,0.25)',
+      };
+    }
+
+    if (!syncState.lastSync) {
+      return {
+        label: 'Ultima sync: pendiente',
+        color: 'var(--warning)',
+        background: 'rgba(245,158,11,0.1)',
+        border: 'rgba(245,158,11,0.35)',
+      };
+    }
+
+    const diffMs = Math.max(0, now - syncState.lastSync.getTime());
+    const diffMin = Math.floor(diffMs / 60_000);
+    const label = diffMin < 1
+      ? 'Ultima sync: hace menos de 1m'
+      : `Ultima sync: hace ${diffMin}m`;
+    const isStale = diffMin > 15;
+
+    return {
+      label,
+      color: isStale ? 'var(--warning)' : 'var(--success)',
+      background: isStale ? 'rgba(245,158,11,0.1)' : 'rgba(16,185,129,0.08)',
+      border: isStale ? 'rgba(245,158,11,0.35)' : 'rgba(16,185,129,0.2)',
+    };
+  };
+
   // ── Indicador de red ────────────────────────────────────────
   const NetIndicator = () => {
+    const lastSync = getLastSyncInfo();
+
     if (status === 'checking') return (
       <div style={{ display: 'flex', alignItems: 'center', gap: '5px' }}>
         <div style={{ width: '7px', height: '7px', borderRadius: '50%', background: 'var(--warning)', animation: 'pulse 1s infinite' }} />
@@ -61,6 +121,9 @@ export function Topbar() {
         border: '1px solid rgba(239,68,68,0.25)', borderRadius: '20px' }}>
         <div style={{ width: '7px', height: '7px', borderRadius: '50%', background: 'var(--danger)' }} />
         <span style={{ fontSize: '11px', fontWeight: 600, color: 'var(--danger)' }}>Sin conexión</span>
+        <span style={{ fontSize: '10px', color: 'var(--text-subtle)', fontWeight: 600 }}>
+          - {lastSync.label.replace('Ultima sync: ', '')}
+        </span>
         {syncState.pendientes > 0 && (
           <span style={{ fontSize: '10px', color: 'var(--danger)', fontWeight: 700 }}>
             · {syncState.pendientes} pendientes
@@ -116,6 +179,26 @@ export function Topbar() {
     );
   };
 
+  const LastSyncIndicator = () => {
+    const info = getLastSyncInfo();
+
+    return (
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: '6px',
+        padding: '4px 10px',
+        background: info.background,
+        border: `1px solid ${info.border}`,
+        borderRadius: '20px',
+        whiteSpace: 'nowrap',
+      }}>
+        <div style={{ width: '7px', height: '7px', borderRadius: '50%', background: info.color }} />
+        <span style={{ fontSize: '11px', fontWeight: 600, color: info.color }}>
+          {info.label}
+        </span>
+      </div>
+    );
+  };
+
   return (
     <header style={{
       height: '52px',
@@ -139,7 +222,41 @@ export function Topbar() {
 
       {/* Indicador de red — oculto en xs */}
       <div className="hide-xs">
-        <NetIndicator />
+        <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+          <NetIndicator />
+          <LastSyncIndicator />
+          {isOnline && (
+            <button
+              onClick={handleSyncNow}
+              disabled={isSyncing}
+              title={syncError ?? 'Sincronizar ahora'}
+              style={{
+                minHeight: '28px',
+                padding: '0 10px',
+                borderRadius: '6px',
+                border: '1px solid var(--border)',
+                background: isSyncing ? 'var(--bg-elevated)' : 'var(--accent)',
+                color: isSyncing ? 'var(--text-muted)' : '#fff',
+                cursor: isSyncing ? 'wait' : 'pointer',
+                fontSize: '11px',
+                fontWeight: 700,
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {isSyncing ? 'Sincronizando...' : 'Sincronizar ahora'}
+            </button>
+          )}
+          {syncFeedback && (
+            <span style={{
+              fontSize: '11px',
+              fontWeight: 600,
+              color: syncFeedback.includes('No se') ? 'var(--danger)' : 'var(--success)',
+              whiteSpace: 'nowrap',
+            }}>
+              {syncFeedback}
+            </span>
+          )}
+        </div>
       </div>
 
       {/* Theme toggle */}

--- a/apps/renderer/src/hooks/useNetworkStatus.ts
+++ b/apps/renderer/src/hooks/useNetworkStatus.ts
@@ -22,24 +22,32 @@ export function useNetworkStatus() {
   const isAuthenticated = useAuthStore(s => s.isAuthenticated);
   const [status,    setStatus]    = useState<NetworkStatus>('checking');
   const [syncState, setSyncState] = useState<SyncState>({ pendientes: 0, sincronizados: 0, errores: 0, lastSync: null });
+  const [isSyncing, setIsSyncing] = useState(false);
+  const [syncError, setSyncError] = useState<string | null>(null);
   const statusRef = useRef(status);
   const pingTimer = useRef<ReturnType<typeof setInterval> | null>(null);
 
   // Ping real al servidor
   const checkServer = useCallback(async () => {
     try {
-      await api.get('/health', {
-        timeout: 4000,
-        baseURL: '',
-      });
-      setStatus('online');
+      if (!isAuthenticated) {
+        await api.get('/health', {
+          timeout: 4000,
+          baseURL: '',
+        });
+        setStatus('online');
+        return;
+      }
+
+      const { data } = await api.get('/inventario/status', { timeout: 4000 });
+      setStatus(data.online ? 'online' : 'offline');
     } catch (err: unknown) {
       // BUG-M01: loguear para trazabilidad; la UI sigue mostrando modo offline
       const msg = (err as { message?: string })?.message ?? String(err);
       console.warn('[useNetworkStatus] ping fallido:', msg);
       setStatus('offline');
     }
-  }, []);
+  }, [isAuthenticated]);
 
   // Obtener conteo de pendientes
   const fetchSyncState = useCallback(async () => {
@@ -53,13 +61,50 @@ export function useNetworkStatus() {
     }
 
     try {
-      const { data } = await api.get('/inventario/sync-pendientes', { timeout: 4000 });
-      setSyncState({ pendientes: data.pendientes, sincronizados: data.sincronizados ?? 0, errores: data.errores, lastSync: new Date() });
+      const [pendientesRes, snapshotRes] = await Promise.all([
+        api.get('/inventario/sync-pendientes', { timeout: 4000 }),
+        api.get('/sync/snapshot/status', { timeout: 4000 }),
+      ]);
+      const lastSyncAt = snapshotRes.data.lastSyncAt
+        ? new Date(snapshotRes.data.lastSyncAt)
+        : null;
+
+      setSyncState({
+        pendientes:    pendientesRes.data.pendientes,
+        sincronizados: pendientesRes.data.sincronizados ?? 0,
+        errores:       pendientesRes.data.errores,
+        lastSync:      lastSyncAt,
+      });
     } catch (err) {
       console.error('[useNetworkStatus] Error al obtener estado de sincronizacion:', err);
       // Si falla, conservamos el ultimo estado conocido.
     }
   }, [isAuthenticated]);
+
+  const syncNow = useCallback(async () => {
+    if (!isAuthenticated || statusRef.current !== 'online' || isSyncing) return null;
+
+    setIsSyncing(true);
+    setSyncError(null);
+
+    try {
+      const { data } = await api.post('/sync/snapshot', undefined, { timeout: 30_000 });
+      const lastSyncAt = data.lastSyncAt ? new Date(data.lastSyncAt) : new Date();
+
+      setSyncState(prev => ({
+        ...prev,
+        lastSync: lastSyncAt,
+      }));
+      await fetchSyncState();
+      return data;
+    } catch (err: any) {
+      const message = err?.response?.data?.error ?? 'No se pudo sincronizar ahora';
+      setSyncError(message);
+      throw err;
+    } finally {
+      setIsSyncing(false);
+    }
+  }, [fetchSyncState, isAuthenticated, isSyncing]);
 
   useEffect(() => {
     statusRef.current = status;
@@ -67,7 +112,7 @@ export function useNetworkStatus() {
 
   useEffect(() => {
     // Escuchar eventos del browser
-    const onOnline  = () => { setStatus('online');  checkServer(); fetchSyncState(); };
+    const onOnline  = () => { setStatus('checking'); checkServer(); fetchSyncState(); };
     const onOffline = () => setStatus('offline');
 
     window.addEventListener('online',  onOnline);
@@ -96,7 +141,10 @@ export function useNetworkStatus() {
     isOffline:  status === 'offline',
     isChecking: status === 'checking',
     syncState,
+    isSyncing,
+    syncError,
     checkNow:   checkServer,
     refreshSync: fetchSyncState,
+    syncNow,
   };
 }

--- a/apps/server/src/adapters/http/routes/inventario.routes.ts
+++ b/apps/server/src/adapters/http/routes/inventario.routes.ts
@@ -28,8 +28,9 @@ async function getStockTotal(productoId: number): Promise<number> {
 }
 
 // ── GET /api/inventario/status ──────────────────────────────────────────
-inventarioRoutes.get('/status', roleMiddleware('ADMIN', 'BODEGA', 'CAJERO'), (_req, res) => {
-  res.json({ online: SyncService.isOnline() });
+inventarioRoutes.get('/status', roleMiddleware('ADMIN', 'BODEGA', 'CAJERO'), async (_req, res) => {
+  const online = await SyncService.checkConnectivity();
+  res.json({ online });
 });
 
 // ── GET /api/inventario/stock/:sucursalId ───────────────────────────────

--- a/apps/server/src/adapters/http/routes/sync.routes.ts
+++ b/apps/server/src/adapters/http/routes/sync.routes.ts
@@ -5,10 +5,31 @@
  */
 import { Router, Request, Response, NextFunction } from 'express';
 import { roleMiddleware } from '../middleware/role.middleware';
-import { bootstrapSnapshot, refreshSnapshot } from '../../sync/snapshot.service';
+import { bootstrapSnapshot, getLastSnapshotAt, refreshSnapshot } from '../../sync/snapshot.service';
 import { SyncService } from '../../sync/sync.service';
 
 export const syncRoutes = Router();
+
+syncRoutes.get(
+  '/snapshot/status',
+  roleMiddleware('ADMIN', 'BODEGA', 'CAJERO'),
+  async (req: Request, res: Response) => {
+    const sucursalId = req.usuario?.sucursalId;
+
+    if (!sucursalId) {
+      return res.status(400).json({ error: 'Tu usuario no tiene sucursal asignada' });
+    }
+
+    const lastSyncAt = getLastSnapshotAt(sucursalId);
+    const online = await SyncService.checkConnectivity();
+
+    return res.json({
+      online,
+      sucursalId,
+      lastSyncAt: lastSyncAt ? lastSyncAt.toISOString() : null,
+    });
+  },
+);
 
 syncRoutes.post(
   '/snapshot',
@@ -29,8 +50,13 @@ syncRoutes.post(
       const counts = full
         ? await bootstrapSnapshot(sucursalId)
         : await refreshSnapshot(sucursalId);
+      const lastSyncAt = getLastSnapshotAt(sucursalId);
 
-      return res.json({ ok: true, counts });
+      return res.json({
+        ok: true,
+        counts,
+        lastSyncAt: lastSyncAt ? lastSyncAt.toISOString() : null,
+      });
     } catch (err) {
       return next(err);
     }

--- a/apps/server/src/adapters/sync/snapshot.service.ts
+++ b/apps/server/src/adapters/sync/snapshot.service.ts
@@ -200,6 +200,10 @@ export async function refreshSnapshot(sucursalId: number): Promise<SnapshotCount
   };
 }
 
+export function getLastSnapshotAt(sucursalId: number): Date | null {
+  return lastRefresh.get(sucursalId) ?? null;
+}
+
 export const SnapshotService = {
   start(sucursalId: number) {
     if (SyncService.isOnline()) {


### PR DESCRIPTION
## Resumen
- Agrega indicador de última sincronización en el Topbar.
- Añade botón manual “Sincronizar ahora”.
- Muestra estado de carga y mensaje de resultado después de sincronizar.
- Agrega endpoint para consultar la última sincronización del snapshot.
- Devuelve `lastSyncAt` después de ejecutar una sincronización manual.

## Validación
- Build de renderer exitoso.
- Build de server exitoso.
