### PR TITLE
fix(T-07E.6): usar cola local para conteo de pendientes

### DIFF
--- a/apps/server/src/adapters/http/routes/inventario.routes.ts
+++ b/apps/server/src/adapters/http/routes/inventario.routes.ts
@@ -13,6 +13,7 @@ import { roleMiddleware } from '../middleware/role.middleware';
 import { assertSameSucursal } from '../middleware/sucursal.guard';
 import { logPendiente, OfflineCache, SyncService } from '../../sync/sync.service';
 import { obtenerStockSucursalSqlite } from '../../db/sqlite/sqlite.client';
+import { contarPendientes } from '../../sync/sync.local';
 
 export const inventarioRoutes = Router();
 
@@ -441,20 +442,19 @@ inventarioRoutes.get('/sync-pendientes', async (req: Request, res: Response, nex
     const usuarioId  = req.usuario?.id    ?? null;
     const sucursalId = req.usuario?.sucursalId ?? null;
     const esAdmin    = req.usuario?.rol === 'ADMIN';
+    const locales    = contarPendientes();
 
     // BUG-M10: filtrar por usuarioId directamente en vez de string matching sobre payload JSON
     const whereBase = (!esAdmin && usuarioId) ? { usuarioId } : {};
 
-    const [pendientes, sincronizados, errores] = await Promise.all([
-      prisma.syncLog.count({ where: { ...whereBase, status: 'PENDIENTE' } }),
+    const [sincronizados] = await Promise.all([
       prisma.syncLog.count({ where: { ...whereBase, status: 'SINCRONIZADO' } }),
-      prisma.syncLog.count({ where: { ...whereBase, status: 'ERROR' } }),
     ]);
 
     return res.json({
-      pendientes,
+      pendientes: locales.pendientes,
       sincronizados,
-      errores,
+      errores:    locales.errores,
       online:     SyncService.isOnline(),
       sucursalId,
     });


### PR DESCRIPTION
## Resumen
- Ajusta el endpoint de pendientes de sincronización para usar la cola local de SQLite.
- Corrige el caso donde el Topbar seguía mostrando operaciones “por sincronizar” aunque la cola offline ya estuviera drenada.
- Mantiene el conteo de sincronizados desde `syncLog` remoto.

## Motivo
Durante la prueba QA de T-07E.6 se detectó que, después de reconectar y sincronizar, el indicador podía seguir mostrando pendientes porque estaba leyendo los registros remotos de `syncLog` en lugar del estado real de la cola local.

## Validación
- Se validó el ciclo offline/online creando productos en modo sin conexión.
- Se confirmó que, al reconectar, la cola local queda sin pendientes.
- TypeScript del server ejecutado correctamente.
