### PR TITLE
feat(HU-16): T-16.1 — migración Prisma para ecommerce

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,4 @@ apps/renderer/vite.config.d.ts
 *.db-shm
 *.db-wal
 supabase/.temp/
-*.sql
 supabase/

--- a/apps/server/prisma/migrations/20260507000000_t16_1_ecommerce_pedidos/migration.sql
+++ b/apps/server/prisma/migrations/20260507000000_t16_1_ecommerce_pedidos/migration.sql
@@ -1,0 +1,59 @@
+-- T-16.1: Tablas para ecommerce — zonas_envio, pedidos_online, pedidos_online_detalle
+-- Agrega stock_reservado a stock_sucursal para reservas atómicas sin afectar stock disponible.
+-- cliente_id en pedidos_online queda nullable hasta que T-17.1 cree clientes_ecommerce.
+
+-- Columna stock_reservado en tabla existente
+ALTER TABLE "stock_sucursal" ADD COLUMN "stock_reservado" INTEGER NOT NULL DEFAULT 0;
+
+-- Zonas geográficas mapeadas a una sucursal preferente para despacho
+CREATE TABLE "zonas_envio" (
+    "id"                     SERIAL PRIMARY KEY,
+    "nombre"                 TEXT NOT NULL,
+    "descripcion"            TEXT,
+    "sucursal_id_preferente" INTEGER REFERENCES "sucursales"("id"),
+    "costo_envio"            DOUBLE PRECISION NOT NULL DEFAULT 0,
+    "activo"                 BOOLEAN NOT NULL DEFAULT true
+);
+
+-- Pedidos realizados desde la app ecommerce
+CREATE TABLE "pedidos_online" (
+    "id"              SERIAL PRIMARY KEY,
+    "cliente_id"      INTEGER,                          -- FK a clientes_ecommerce (T-17.1)
+    "sucursal_id"     INTEGER NOT NULL REFERENCES "sucursales"("id"),
+    "zona_envio_id"   INTEGER REFERENCES "zonas_envio"("id"),
+    "tipo_entrega"    TEXT NOT NULL DEFAULT 'RETIRO',   -- RETIRO | ENVIO
+    "estado"          TEXT NOT NULL DEFAULT 'RECIBIDO', -- RECIBIDO | PREPARANDO | LISTO | ENTREGADO | CANCELADO
+    "cliente_nombre"  TEXT,
+    "cliente_tel"     TEXT,
+    "direccion_envio" TEXT,
+    "subtotal"        DOUBLE PRECISION NOT NULL DEFAULT 0,
+    "costo_envio"     DOUBLE PRECISION NOT NULL DEFAULT 0,
+    "total"           DOUBLE PRECISION NOT NULL DEFAULT 0,
+    "observaciones"   TEXT,
+    "creado_en"       TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "actualizado_en"  TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX "pedidos_online_sucursal_id_estado_idx" ON "pedidos_online"("sucursal_id", "estado");
+CREATE INDEX "pedidos_online_cliente_id_idx"         ON "pedidos_online"("cliente_id");
+
+-- Líneas de cada pedido online
+CREATE TABLE "pedidos_online_detalle" (
+    "id"          SERIAL PRIMARY KEY,
+    "pedido_id"   INTEGER NOT NULL REFERENCES "pedidos_online"("id") ON DELETE CASCADE,
+    "producto_id" INTEGER NOT NULL REFERENCES "productos"("id"),
+    "cantidad"    DOUBLE PRECISION NOT NULL,
+    "precio_unit" DOUBLE PRECISION NOT NULL,
+    "subtotal"    DOUBLE PRECISION NOT NULL
+);
+
+-- Seed: 5 zonas mapeadas a las sucursales existentes (sucursal_id 1 a 5 si existen)
+-- La FK usa ON DELETE SET NULL implícito al ser nullable — no se define aquí para evitar
+-- fallo si hay menos de 5 sucursales en el entorno de prueba.
+INSERT INTO "zonas_envio" ("nombre", "descripcion", "sucursal_id_preferente", "costo_envio") VALUES
+    ('Zona Centro',        'Centro histórico y alrededores',   1, 3.00),
+    ('Zona Norte',         'Apopa, Mejicanos, Cuscatancingo',  1, 4.50),
+    ('Zona Sur',           'Soyapango, Ilopango, San Marcos',  1, 4.50),
+    ('Zona Oriente',       'San Miguel, Usulután, La Unión',   1, 8.00),
+    ('Zona Occidente',     'Santa Ana, Sonsonate, Ahuachapán', 1, 8.00)
+ON CONFLICT DO NOTHING;

--- a/apps/server/prisma/schema.prisma
+++ b/apps/server/prisma/schema.prisma
@@ -15,10 +15,12 @@ model Sucursal {
   nombre      String
   direccion   String?
   telefono    String?
-  usuarios    Usuario[]
-  facturas    FacturaDte[]
-  stocks      StockSucursal[]
-  recepciones RecepcionMercancia[]
+  usuarios       Usuario[]
+  facturas       FacturaDte[]
+  stocks         StockSucursal[]
+  recepciones    RecepcionMercancia[]
+  zonasEnvio     ZonaEnvio[]
+  pedidosOnline  PedidoOnline[]
   @@map("sucursales")
 }
 
@@ -65,9 +67,10 @@ model Producto {
   creadoEn           DateTime @default(now()) @map("creado_en")
   updatedAt          DateTime @default(now()) @updatedAt @map("updated_at")
   categoria          Categoria?    @relation(fields: [categoriaId], references: [id])
-  detallesVenta      DetalleVenta[]
-  stocks             StockSucursal[]
-  detallesRecepcion  DetalleRecepcion[]
+  detallesVenta         DetalleVenta[]
+  stocks                StockSucursal[]
+  detallesRecepcion     DetalleRecepcion[]
+  detallesPedidoOnline  PedidoOnlineDetalle[]
   @@map("productos")
 }
 
@@ -75,9 +78,10 @@ model StockSucursal {
   id            Int      @id @default(autoincrement())
   productoId    Int      @map("producto_id")
   sucursalId    Int      @map("sucursal_id")
-  cantidad      Int      @default(0)
-  minimo        Int      @default(0)
-  actualizadoEn DateTime @default(now()) @updatedAt @map("actualizado_en")
+  cantidad        Int      @default(0)
+  minimo          Int      @default(0)
+  stockReservado  Int      @default(0) @map("stock_reservado")
+  actualizadoEn   DateTime @default(now()) @updatedAt @map("actualizado_en")
   updatedAt     DateTime @default(now()) @updatedAt @map("updated_at")
   producto      Producto  @relation(fields: [productoId], references: [id])
   sucursal      Sucursal  @relation(fields: [sucursalId], references: [id])
@@ -175,4 +179,54 @@ model DetalleRecepcion {
   recepcion   RecepcionMercancia @relation(fields: [recepcionId], references: [id], onDelete: Cascade)
   producto    Producto           @relation(fields: [productoId], references: [id])
   @@map("detalles_recepcion")
+}
+
+// ── HU-16: Ecommerce ────────────────────────────────────────────
+
+model ZonaEnvio {
+  id                 Int       @id @default(autoincrement())
+  nombre             String
+  descripcion        String?
+  sucursalPreferente Int?      @map("sucursal_id_preferente")
+  costoEnvio         Float     @default(0) @map("costo_envio")
+  activo             Boolean   @default(true)
+  sucursal           Sucursal? @relation(fields: [sucursalPreferente], references: [id])
+  pedidos            PedidoOnline[]
+  @@map("zonas_envio")
+}
+
+model PedidoOnline {
+  id             Int      @id @default(autoincrement())
+  clienteId      Int?     @map("cliente_id")
+  sucursalId     Int      @map("sucursal_id")
+  zonaEnvioId    Int?     @map("zona_envio_id")
+  tipoEntrega    String   @default("RETIRO") @map("tipo_entrega")
+  estado         String   @default("RECIBIDO")
+  clienteNombre  String?  @map("cliente_nombre")
+  clienteTel     String?  @map("cliente_tel")
+  direccionEnvio String?  @map("direccion_envio")
+  subtotal       Float    @default(0)
+  costoEnvio     Float    @default(0) @map("costo_envio")
+  total          Float    @default(0)
+  observaciones  String?
+  creadoEn       DateTime @default(now()) @map("creado_en")
+  actualizadoEn  DateTime @default(now()) @updatedAt @map("actualizado_en")
+  sucursal       Sucursal   @relation(fields: [sucursalId], references: [id])
+  zonaEnvio      ZonaEnvio? @relation(fields: [zonaEnvioId], references: [id])
+  detalles       PedidoOnlineDetalle[]
+  @@index([sucursalId, estado])
+  @@index([clienteId])
+  @@map("pedidos_online")
+}
+
+model PedidoOnlineDetalle {
+  id         Int    @id @default(autoincrement())
+  pedidoId   Int    @map("pedido_id")
+  productoId Int    @map("producto_id")
+  cantidad   Float
+  precioUnit Float  @map("precio_unit")
+  subtotal   Float
+  pedido     PedidoOnline @relation(fields: [pedidoId], references: [id], onDelete: Cascade)
+  producto   Producto     @relation(fields: [productoId], references: [id])
+  @@map("pedidos_online_detalle")
 }


### PR DESCRIPTION
Tablas nuevas: zonas_envio (con sucursal_id_preferente y costo_envio), pedidos_online (tipoEntrega RETIRO|ENVIO, máquina de estado, clienteId nullable hasta HU-17), pedidos_online_detalle.
Campo stock_reservado añadido a stock_sucursal para reservas atómicas sin afectar el stock disponible en POS.
Seed: 5 zonas mapeadas a sucursal 1 (Centro, Norte, Sur, Oriente, Occidente). Índices: (sucursal_id, estado) y (cliente_id) en pedidos_online. Elimina *.sql de .gitignore para que las migraciones se puedan rastrear.