### PR TITLE
feat(HU-17): T-17.1 — migración Prisma clientes_ecommerce

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,4 @@ apps/renderer/vite.config.d.ts
 *.db-shm
 *.db-wal
 supabase/.temp/
-*.sql
 supabase/

--- a/apps/server/prisma/migrations/20260507010000_t17_1_clientes_ecommerce/migration.sql
+++ b/apps/server/prisma/migrations/20260507010000_t17_1_clientes_ecommerce/migration.sql
@@ -1,0 +1,24 @@
+-- T-17.1: Tabla clientes_ecommerce y FK desde pedidos_online.cliente_id
+-- Depende de T-16.1 (20260507000000) — debe ejecutarse después de esa migración.
+
+-- Cuenta del cliente del ecommerce (distinto al Usuario interno del POS)
+CREATE TABLE "clientes_ecommerce" (
+    "id"             SERIAL PRIMARY KEY,
+    "nombre"         TEXT NOT NULL,
+    "email"          TEXT NOT NULL,
+    "password_hash"  TEXT NOT NULL,
+    "telefono"       TEXT,
+    "direccion"      TEXT,
+    "activo"         BOOLEAN NOT NULL DEFAULT true,
+    "fecha_registro" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX "clientes_ecommerce_email_key" ON "clientes_ecommerce"("email");
+
+-- Agregar FK real desde pedidos_online.cliente_id → clientes_ecommerce
+-- Los pedidos huérfanos (cliente_id IS NULL) creados antes de esta migración
+-- permanecen válidos porque la columna sigue siendo nullable.
+ALTER TABLE "pedidos_online"
+    ADD CONSTRAINT "pedidos_online_cliente_id_fkey"
+    FOREIGN KEY ("cliente_id") REFERENCES "clientes_ecommerce"("id")
+    ON DELETE SET NULL;

--- a/apps/server/prisma/schema.prisma
+++ b/apps/server/prisma/schema.prisma
@@ -15,10 +15,12 @@ model Sucursal {
   nombre      String
   direccion   String?
   telefono    String?
-  usuarios    Usuario[]
-  facturas    FacturaDte[]
-  stocks      StockSucursal[]
-  recepciones RecepcionMercancia[]
+  usuarios       Usuario[]
+  facturas       FacturaDte[]
+  stocks         StockSucursal[]
+  recepciones    RecepcionMercancia[]
+  zonasEnvio     ZonaEnvio[]
+  pedidosOnline  PedidoOnline[]
   @@map("sucursales")
 }
 
@@ -65,9 +67,10 @@ model Producto {
   creadoEn           DateTime @default(now()) @map("creado_en")
   updatedAt          DateTime @default(now()) @updatedAt @map("updated_at")
   categoria          Categoria?    @relation(fields: [categoriaId], references: [id])
-  detallesVenta      DetalleVenta[]
-  stocks             StockSucursal[]
-  detallesRecepcion  DetalleRecepcion[]
+  detallesVenta         DetalleVenta[]
+  stocks                StockSucursal[]
+  detallesRecepcion     DetalleRecepcion[]
+  detallesPedidoOnline  PedidoOnlineDetalle[]
   @@map("productos")
 }
 
@@ -75,9 +78,10 @@ model StockSucursal {
   id            Int      @id @default(autoincrement())
   productoId    Int      @map("producto_id")
   sucursalId    Int      @map("sucursal_id")
-  cantidad      Int      @default(0)
-  minimo        Int      @default(0)
-  actualizadoEn DateTime @default(now()) @updatedAt @map("actualizado_en")
+  cantidad        Int      @default(0)
+  minimo          Int      @default(0)
+  stockReservado  Int      @default(0) @map("stock_reservado")
+  actualizadoEn   DateTime @default(now()) @updatedAt @map("actualizado_en")
   updatedAt     DateTime @default(now()) @updatedAt @map("updated_at")
   producto      Producto  @relation(fields: [productoId], references: [id])
   sucursal      Sucursal  @relation(fields: [sucursalId], references: [id])
@@ -175,4 +179,70 @@ model DetalleRecepcion {
   recepcion   RecepcionMercancia @relation(fields: [recepcionId], references: [id], onDelete: Cascade)
   producto    Producto           @relation(fields: [productoId], references: [id])
   @@map("detalles_recepcion")
+}
+
+// ── HU-17: Autenticación de cliente ecommerce ───────────────────
+
+model ClienteEcommerce {
+  id            Int      @id @default(autoincrement())
+  nombre        String
+  email         String   @unique
+  passwordHash  String   @map("password_hash")
+  telefono      String?
+  direccion     String?
+  activo        Boolean  @default(true)
+  fechaRegistro DateTime @default(now()) @map("fecha_registro")
+  pedidos       PedidoOnline[]
+  @@map("clientes_ecommerce")
+}
+
+// ── HU-16: Ecommerce ────────────────────────────────────────────
+
+model ZonaEnvio {
+  id                 Int       @id @default(autoincrement())
+  nombre             String
+  descripcion        String?
+  sucursalPreferente Int?      @map("sucursal_id_preferente")
+  costoEnvio         Float     @default(0) @map("costo_envio")
+  activo             Boolean   @default(true)
+  sucursal           Sucursal? @relation(fields: [sucursalPreferente], references: [id])
+  pedidos            PedidoOnline[]
+  @@map("zonas_envio")
+}
+
+model PedidoOnline {
+  id             Int      @id @default(autoincrement())
+  clienteId      Int?     @map("cliente_id")
+  sucursalId     Int      @map("sucursal_id")
+  zonaEnvioId    Int?     @map("zona_envio_id")
+  tipoEntrega    String   @default("RETIRO") @map("tipo_entrega")
+  estado         String   @default("RECIBIDO")
+  clienteNombre  String?  @map("cliente_nombre")
+  clienteTel     String?  @map("cliente_tel")
+  direccionEnvio String?  @map("direccion_envio")
+  subtotal       Float    @default(0)
+  costoEnvio     Float    @default(0) @map("costo_envio")
+  total          Float    @default(0)
+  observaciones  String?
+  creadoEn       DateTime @default(now()) @map("creado_en")
+  actualizadoEn  DateTime @default(now()) @updatedAt @map("actualizado_en")
+  sucursal       Sucursal?         @relation(fields: [sucursalId], references: [id])
+  zonaEnvio      ZonaEnvio?        @relation(fields: [zonaEnvioId], references: [id])
+  cliente        ClienteEcommerce? @relation(fields: [clienteId], references: [id])
+  detalles       PedidoOnlineDetalle[]
+  @@index([sucursalId, estado])
+  @@index([clienteId])
+  @@map("pedidos_online")
+}
+
+model PedidoOnlineDetalle {
+  id         Int    @id @default(autoincrement())
+  pedidoId   Int    @map("pedido_id")
+  productoId Int    @map("producto_id")
+  cantidad   Float
+  precioUnit Float  @map("precio_unit")
+  subtotal   Float
+  pedido     PedidoOnline @relation(fields: [pedidoId], references: [id], onDelete: Cascade)
+  producto   Producto     @relation(fields: [productoId], references: [id])
+  @@map("pedidos_online_detalle")
 }


### PR DESCRIPTION
Tabla clientes_ecommerce (id, nombre, email UNIQUE, password_hash, telefono, direccion, activo, fecha_registro).
FK pedidos_online.cliente_id → clientes_ecommerce ON DELETE SET NULL. Los pedidos huérfanos anteriores a esta migración permanecen válidos.

Incluye schema acumulativo con T-16.1 (ecommerce base: zonas_envio, pedidos_online, pedidos_online_detalle, stock_reservado). Rebasar sobre HU-16 merged en main antes de abrir PR.