### PR TITLE
T-17.2 T-17.3: agregar auth ecommerce y pedidos por cliente

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,8 @@ DIRECT_URL=postgresql://<usuario>:<password>@<host>:5432/<db>
 # Mínimo 32 caracteres aleatorios; rotar si se filtra
 JWT_SECRET=<min-32-chars-aleatorios>
 JWT_EXPIRES_IN=2h
+JWT_ECOMMERCE_SECRET=<min-32-chars-aleatorios-distinto-a-JWT_SECRET>
+ECOMMERCE_JWT_EXPIRES_IN=7d
 
 # Clave para cifrado interno de datos sensibles
 CRYPTO_SECRET=<min-32-chars-aleatorios>

--- a/apps/server/src/adapters/http/middleware/cliente-auth.middleware.ts
+++ b/apps/server/src/adapters/http/middleware/cliente-auth.middleware.ts
@@ -1,0 +1,46 @@
+import { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+import { env } from '../../../config/env';
+import { prisma } from '../../db/prisma/prisma.client';
+
+interface ClienteJwtPayload {
+  id: number;
+  rol: 'CLIENTE';
+  email: string;
+}
+
+export async function authenticateCliente(req: Request, res: Response, next: NextFunction) {
+  const auth = req.headers.authorization;
+
+  if (!auth?.startsWith('Bearer ')) {
+    return res.status(401).json({ error: 'Token de cliente requerido' });
+  }
+
+  try {
+    const token = auth.slice(7);
+    const payload = jwt.verify(token, env.ecommerceJwt.secret) as ClienteJwtPayload;
+
+    if (payload.rol !== 'CLIENTE') {
+      return res.status(401).json({ error: 'Token de cliente invalido' });
+    }
+
+    const cliente = await prisma.clienteEcommerce.findFirst({
+      where: { id: payload.id, email: payload.email, activo: true },
+      select: { id: true, email: true },
+    });
+
+    if (!cliente) {
+      return res.status(401).json({ error: 'Cliente no encontrado o inactivo' });
+    }
+
+    req.cliente = {
+      id: cliente.id,
+      rol: 'CLIENTE',
+      email: cliente.email,
+    };
+
+    return next();
+  } catch {
+    return res.status(401).json({ error: 'Token de cliente invalido o expirado' });
+  }
+}

--- a/apps/server/src/adapters/http/routes/auth.routes.ts
+++ b/apps/server/src/adapters/http/routes/auth.routes.ts
@@ -1,11 +1,11 @@
 import { Router, Request, Response, NextFunction } from 'express';
 import bcrypt from 'bcryptjs';
-import jwt from 'jsonwebtoken';
 import { z } from 'zod';
 import { prisma } from '../../db/prisma/prisma.client';
 import { env } from '../../../config/env';
 import type { UserRole } from '../../../types/roles';
 import { getSqliteDb } from '../../db/sqlite.client';
+import { issueJwt as signJwt } from '../services/jwt.service';
 
 export const authRoutes = Router();
 
@@ -28,7 +28,7 @@ interface UsuarioPayload {
  */
 
 function issueJwt(usuario: UsuarioPayload): string {
-  return jwt.sign(
+  return signJwt(
     {
       id:         usuario.id,
       rol:        usuario.rol,
@@ -36,7 +36,7 @@ function issueJwt(usuario: UsuarioPayload): string {
       email:      usuario.email,
     },
     env.jwt.secret,
-    { expiresIn: env.jwt.expiresIn } as jwt.SignOptions,
+    env.jwt.expiresIn,
   );
 }
 

--- a/apps/server/src/adapters/http/routes/ecommerce-auth.routes.ts
+++ b/apps/server/src/adapters/http/routes/ecommerce-auth.routes.ts
@@ -1,0 +1,157 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import bcrypt from 'bcryptjs';
+import { Prisma } from '@prisma/client';
+import { z } from 'zod';
+import { prisma } from '../../db/prisma/prisma.client';
+import { env } from '../../../config/env';
+import { issueJwt } from '../services/jwt.service';
+import { authenticateCliente } from '../middleware/cliente-auth.middleware';
+
+export const ecommerceAuthRoutes = Router();
+
+const ClienteRegistroSchema = z.object({
+  nombre: z.string().trim().min(2, 'Nombre requerido'),
+  email: z.string().trim().email('Email invalido'),
+  password: z.string().min(8, 'La contrasena debe tener al menos 8 caracteres'),
+  telefono: z.string().trim().min(7).optional(),
+  direccion: z.string().trim().min(5).optional(),
+});
+
+const ClienteLoginSchema = z.object({
+  email: z.string().trim().email('Email invalido'),
+  password: z.string().min(1, 'Contrasena requerida'),
+});
+
+function toClienteResponse(cliente: {
+  id: number;
+  nombre: string;
+  email: string;
+  telefono: string | null;
+  direccion: string | null;
+  fechaRegistro: Date;
+}) {
+  return {
+    id: cliente.id,
+    nombre: cliente.nombre,
+    email: cliente.email,
+    rol: 'CLIENTE' as const,
+    telefono: cliente.telefono,
+    direccion: cliente.direccion,
+    fechaRegistro: cliente.fechaRegistro,
+  };
+}
+
+function issueClienteJwt(cliente: { id: number; email: string }) {
+  return issueJwt(
+    {
+      id: cliente.id,
+      rol: 'CLIENTE',
+      email: cliente.email,
+    },
+    env.ecommerceJwt.secret,
+    env.ecommerceJwt.expiresIn,
+  );
+}
+
+ecommerceAuthRoutes.post('/register', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const parsed = ClienteRegistroSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({
+        error: 'Datos de cliente invalidos',
+        detalle: parsed.error.flatten().fieldErrors,
+      });
+    }
+
+    const data = parsed.data;
+    const email = data.email.toLowerCase();
+    const passwordHash = await bcrypt.hash(data.password, 10);
+
+    const cliente = await prisma.clienteEcommerce.create({
+      data: {
+        nombre: data.nombre,
+        email,
+        passwordHash,
+        telefono: data.telefono,
+        direccion: data.direccion,
+      },
+      select: {
+        id: true,
+        nombre: true,
+        email: true,
+        telefono: true,
+        direccion: true,
+        fechaRegistro: true,
+      },
+    });
+
+    return res.status(201).json({
+      token: issueClienteJwt(cliente),
+      cliente: toClienteResponse(cliente),
+    });
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+      return res.status(409).json({ error: 'Ya existe un cliente con ese email' });
+    }
+
+    return next(error);
+  }
+});
+
+ecommerceAuthRoutes.post('/login', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const parsed = ClienteLoginSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({
+        error: 'Credenciales invalidas',
+        detalle: parsed.error.flatten().fieldErrors,
+      });
+    }
+
+    const email = parsed.data.email.toLowerCase();
+    const cliente = await prisma.clienteEcommerce.findUnique({
+      where: { email },
+    });
+
+    if (!cliente || !cliente.activo) {
+      return res.status(401).json({ error: 'Credenciales incorrectas' });
+    }
+
+    const passwordOk = await bcrypt.compare(parsed.data.password, cliente.passwordHash);
+    if (!passwordOk) {
+      return res.status(401).json({ error: 'Credenciales incorrectas' });
+    }
+
+    return res.json({
+      token: issueClienteJwt(cliente),
+      cliente: toClienteResponse(cliente),
+    });
+  } catch (error) {
+    return next(error);
+  }
+});
+
+ecommerceAuthRoutes.get('/me', authenticateCliente, async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const clienteId = req.cliente?.id;
+    if (!clienteId) return res.status(401).json({ error: 'Token de cliente requerido' });
+
+    const cliente = await prisma.clienteEcommerce.findUnique({
+      where: { id: clienteId },
+      select: {
+        id: true,
+        nombre: true,
+        email: true,
+        telefono: true,
+        direccion: true,
+        fechaRegistro: true,
+      },
+    });
+
+    if (!cliente) return res.status(404).json({ error: 'Cliente no encontrado' });
+
+    return res.json({ cliente: toClienteResponse(cliente) });
+  } catch (error) {
+    return next(error);
+  }
+});

--- a/apps/server/src/adapters/http/routes/pedidos-online.routes.ts
+++ b/apps/server/src/adapters/http/routes/pedidos-online.routes.ts
@@ -11,6 +11,7 @@ import {
 import { sincronizarStockTotal } from '../services/stock-sync.service';
 import { roleMiddleware } from '../middleware/role.middleware';
 import { assertSameSucursal } from '../middleware/sucursal.guard';
+import { authenticateCliente } from '../middleware/cliente-auth.middleware';
 import { OfflineCache } from '../../sync/sync.service';
 
 export const pedidosOnlinePublicRoutes = Router();
@@ -232,7 +233,7 @@ productosPublicosRoutes.get('/publico/:sucursalId', async (req: Request, res: Re
   }
 });
 
-pedidosOnlinePublicRoutes.post('/', async (req: Request, res: Response, next: NextFunction) => {
+pedidosOnlinePublicRoutes.post('/', authenticateCliente, async (req: Request, res: Response, next: NextFunction) => {
   try {
     const parsed = CrearPedidoOnlineSchema.safeParse(req.body);
     if (!parsed.success) {
@@ -242,7 +243,13 @@ pedidosOnlinePublicRoutes.post('/', async (req: Request, res: Response, next: Ne
       });
     }
 
-    const pedido = await crearPedidoOnline(parsed.data);
+    const clienteId = req.cliente?.id;
+    if (!clienteId) return res.status(401).json({ error: 'Token de cliente requerido' });
+
+    const pedido = await crearPedidoOnline({
+      ...parsed.data,
+      clienteId,
+    });
     OfflineCache.invalidate(`stock:${pedido.sucursalId}`);
     OfflineCache.invalidate('productos:');
 
@@ -252,6 +259,24 @@ pedidosOnlinePublicRoutes.post('/', async (req: Request, res: Response, next: Ne
       return jsonErrorPedido(res, error);
     }
 
+    return next(error);
+  }
+});
+
+pedidosOnlinePublicRoutes.get('/mis', authenticateCliente, async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const clienteId = req.cliente?.id;
+    if (!clienteId) return res.status(401).json({ error: 'Token de cliente requerido' });
+
+    const pedidos = await prisma.pedidoOnline.findMany({
+      where: { clienteId },
+      include: pedidoCompletoInclude,
+      orderBy: { creadoEn: 'desc' },
+      take: 100,
+    });
+
+    return res.json({ total: pedidos.length, pedidos });
+  } catch (error) {
     return next(error);
   }
 });

--- a/apps/server/src/adapters/http/services/jwt.service.ts
+++ b/apps/server/src/adapters/http/services/jwt.service.ts
@@ -1,0 +1,9 @@
+import jwt from 'jsonwebtoken';
+
+export function issueJwt<TPayload extends object>(
+  payload: TPayload,
+  secret: string,
+  expiresIn: string,
+): string {
+  return jwt.sign(payload, secret, { expiresIn } as jwt.SignOptions);
+}

--- a/apps/server/src/adapters/http/services/pedidos-online.service.ts
+++ b/apps/server/src/adapters/http/services/pedidos-online.service.ts
@@ -16,7 +16,6 @@ const ItemPedidoOnlineSchema = z.object({
 });
 
 export const CrearPedidoOnlineSchema = z.object({
-  clienteId: z.number().int().positive().optional(),
   clienteNombre: z.string().trim().min(2).optional(),
   clienteTel: z.string().trim().min(7).optional(),
   tipoEntrega: z.enum([TipoEntregaPedidoOnline.RETIRO, TipoEntregaPedidoOnline.ENVIO]),
@@ -52,7 +51,9 @@ export const CrearPedidoOnlineSchema = z.object({
   }
 });
 
-export type CrearPedidoOnlineInput = z.infer<typeof CrearPedidoOnlineSchema>;
+export type CrearPedidoOnlineInput = z.infer<typeof CrearPedidoOnlineSchema> & {
+  clienteId: number;
+};
 
 export type StockInsuficienteDetalle = {
   productoId: number;
@@ -256,7 +257,7 @@ export async function crearPedidoOnline(input: CrearPedidoOnlineInput): Promise<
     throw new PedidoOnlineServiceError(parsed.error.issues[0]?.message ?? 'Pedido invalido', 400);
   }
 
-  const data = parsed.data;
+  const data = { ...parsed.data, clienteId: input.clienteId };
   const items = normalizarItems(data.items);
 
   return prisma.$transaction(async (tx) => {

--- a/apps/server/src/config/env.ts
+++ b/apps/server/src/config/env.ts
@@ -16,6 +16,14 @@ function required(name: string): string {
   return val;
 }
 
+function requiredAny(...names: string[]): string {
+  for (const name of names) {
+    const val = process.env[name];
+    if (val) return val;
+  }
+  throw new Error(`Variable de entorno requerida: ${names.join(' o ')}`);
+}
+
 // BUG-A09: usar el mismo patrón de nombre que Electron (ferred_branch{BRANCH_ID}.db)
 const branchId = Number(process.env.BRANCH_ID ?? 1);
 const sqliteFallback = path.resolve(process.cwd(), `data/ferred_branch${branchId}.db`);
@@ -28,6 +36,11 @@ export const env = {
   jwt: {
     secret:    required('JWT_SECRET'),
     expiresIn: process.env.JWT_EXPIRES_IN ?? '2h',
+  },
+
+  ecommerceJwt: {
+    secret:    requiredAny('JWT_ECOMMERCE_SECRET', 'ECOMMERCE_SECRET'),
+    expiresIn: process.env.ECOMMERCE_JWT_EXPIRES_IN ?? '7d',
   },
 
   crypto: {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -9,6 +9,7 @@ dotenv.config({ path: path.join(__dirname, '..', '.env') });
 
 import { AlertasService } from './adapters/alertas/alertas.service';
 import { authRoutes }       from './adapters/http/routes/auth.routes';
+import { ecommerceAuthRoutes } from './adapters/http/routes/ecommerce-auth.routes';
 import { usuarioRoutes }    from './adapters/http/routes/usuario.routes';
 import { categoriaRoutes }  from './adapters/http/routes/categoria.routes';
 import { productoRoutes }   from './adapters/http/routes/producto.routes';
@@ -77,6 +78,7 @@ const apiLimiter = rateLimit({
 });
 
 app.use('/api/auth', loginLimiter, authRoutes);
+app.use('/api/ecommerce/auth', loginLimiter, ecommerceAuthRoutes);
 app.get('/health', (_req, res) => res.json({ ok: true }));
 app.use('/api/zonas-envio', zonasEnvioPublicRoutes);
 app.use('/api/productos', productosPublicosRoutes);

--- a/apps/server/src/types/express.d.ts
+++ b/apps/server/src/types/express.d.ts
@@ -10,6 +10,11 @@ declare global {
         sucursalId: number;
         email: string;
       };
+      cliente?: {
+        id: number;
+        rol: 'CLIENTE';
+        email: string;
+      };
     }
   }
 }


### PR DESCRIPTION
Implementa T-17.2 y T-17.3 de HU-17.

Cambios realizados:
- Se agregaron los endpoints de autenticación para clientes ecommerce:
  - POST /api/ecommerce/auth/register
  - POST /api/ecommerce/auth/login
  - GET /api/ecommerce/auth/me
- Se creó el middleware authenticateCliente para validar JWT de clientes.
- Se agregó JWT separado para ecommerce usando JWT_ECOMMERCE_SECRET y rol CLIENTE.
- Se refactorizó la firma de JWT a un helper reutilizable.
- Se protegió POST /api/pedidos-online para que solo clientes autenticados puedan crear pedidos.
- Se dejó de tomar clienteId desde el body y ahora se toma desde el JWT del cliente.
- Se agregó GET /api/pedidos-online/mis para listar los pedidos del cliente autenticado.
- Se actualizaron las variables requeridas en .env.example.

Validaciones realizadas:
- pnpm --dir apps/server exec prisma generate
- pnpm --dir apps/server exec tsc --noEmit
- pnpm --filter server build
- git diff --check --cached
