### PR TITLE
fix: resolver deuda técnica nueva

### DIFF
--- a/apps/server/prisma/migrations/20260507000000_t16_1_ecommerce_pedidos/migration.sql
+++ b/apps/server/prisma/migrations/20260507000000_t16_1_ecommerce_pedidos/migration.sql
@@ -47,13 +47,13 @@ CREATE TABLE "pedidos_online_detalle" (
     "subtotal"    DOUBLE PRECISION NOT NULL
 );
 
--- Seed: 5 zonas mapeadas a las sucursales existentes (sucursal_id 1 a 5 si existen)
--- La FK usa ON DELETE SET NULL implícito al ser nullable — no se define aquí para evitar
--- fallo si hay menos de 5 sucursales en el entorno de prueba.
+-- Seed: 5 zonas de entrega. sucursal_id_preferente en NULL para que la migración
+-- sea idempotente en la shadow database (que arranca sin sucursales). La asignación
+-- real de sucursal se hace en producción vía Prisma Studio o el admin panel.
 INSERT INTO "zonas_envio" ("nombre", "descripcion", "sucursal_id_preferente", "costo_envio") VALUES
-    ('Zona Centro',        'Centro histórico y alrededores',   1, 3.00),
-    ('Zona Norte',         'Apopa, Mejicanos, Cuscatancingo',  1, 4.50),
-    ('Zona Sur',           'Soyapango, Ilopango, San Marcos',  1, 4.50),
-    ('Zona Oriente',       'San Miguel, Usulután, La Unión',   1, 8.00),
-    ('Zona Occidente',     'Santa Ana, Sonsonate, Ahuachapán', 1, 8.00)
+    ('Zona Centro',        'Centro histórico y alrededores',   NULL, 3.00),
+    ('Zona Norte',         'Apopa, Mejicanos, Cuscatancingo',  NULL, 4.50),
+    ('Zona Sur',           'Soyapango, Ilopango, San Marcos',  NULL, 4.50),
+    ('Zona Oriente',       'San Miguel, Usulután, La Unión',   NULL, 8.00),
+    ('Zona Occidente',     'Santa Ana, Sonsonate, Ahuachapán', NULL, 8.00)
 ON CONFLICT DO NOTHING;

--- a/apps/server/prisma/migrations/20260509000000_dt_nueva_b_updated_at_proveedor_usuario/migration.sql
+++ b/apps/server/prisma/migrations/20260509000000_dt_nueva_b_updated_at_proveedor_usuario/migration.sql
@@ -1,0 +1,11 @@
+-- DT-NUEVA-B: Agregar updated_at a proveedores y usuarios para delta sync
+-- Sin esta columna el snapshot.service solo capturaba proveedores NUEVOS (por creadoEn)
+-- y re-sincronizaba TODOS los usuarios en cada refresh (costoso y sin delta real).
+-- Con @updatedAt Prisma actualiza el campo automáticamente en cada update,
+-- lo que permite filtrar por fecha en refreshSnapshot().
+
+ALTER TABLE "proveedores"
+  ADD COLUMN "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+ALTER TABLE "usuarios"
+  ADD COLUMN "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;

--- a/apps/server/prisma/schema.prisma
+++ b/apps/server/prisma/schema.prisma
@@ -44,6 +44,7 @@ model Usuario {
   rol            String
   activo         Boolean  @default(true)
   creadoEn       DateTime @default(now()) @map("creado_en")
+  updatedAt      DateTime @default(now()) @updatedAt @map("updated_at")
   sucursal       Sucursal?    @relation(fields: [sucursalId], references: [id])
   facturas       FacturaDte[]
   syncLogs       SyncLog[]
@@ -173,6 +174,7 @@ model Proveedor {
   direccion   String?
   activo      Boolean  @default(true)
   creadoEn    DateTime @default(now()) @map("creado_en")
+  updatedAt   DateTime @default(now()) @updatedAt @map("updated_at")
   recepciones RecepcionMercancia[]
   @@map("proveedores")
 }

--- a/apps/server/src/adapters/db/sqlite/sqlite.client.ts
+++ b/apps/server/src/adapters/db/sqlite/sqlite.client.ts
@@ -104,6 +104,7 @@
       ss.sucursal_id AS sucursalId,
       ss.cantidad,
       ss.minimo,
+      ss.stock_reservado AS stockReservado,
       ss.actualizado_en AS actualizadoEn,
       p.nombre AS productoNombre,
       p.codigo_barras AS codigoBarras,
@@ -288,6 +289,7 @@
       sucursalId: Number(row.sucursalId),
       cantidad: Number(row.cantidad ?? 0),
       minimo: Number(row.minimo ?? 0),
+      stockReservado: Number(row.stockReservado ?? 0),
       actualizadoEn: row.actualizadoEn,
       producto: {
         id: Number(row.productoId),
@@ -564,28 +566,19 @@
   }
 
   function ensureUpdatedAtColumns(db: Database.Database) {
-    ensureColumn(db, 'categorias', 'updated_at', 'TEXT');
-    ensureColumn(db, 'productos', 'updated_at', 'TEXT');
-    ensureColumn(db, 'stock_sucursal', 'updated_at', 'TEXT');
-    ensureColumn(db, 'usuarios', 'last_synced_at', 'TEXT'); // T-07F.3
+    ensureColumn(db, 'categorias',    'updated_at',     'TEXT');
+    ensureColumn(db, 'productos',     'updated_at',     'TEXT');
+    ensureColumn(db, 'stock_sucursal','updated_at',     'TEXT');
+    ensureColumn(db, 'stock_sucursal','stock_reservado','INTEGER NOT NULL DEFAULT 0');
+    ensureColumn(db, 'proveedores',   'updated_at',     'TEXT');       // DT-NUEVA-B
+    ensureColumn(db, 'usuarios',      'last_synced_at', 'TEXT');       // T-07F.3
+    ensureColumn(db, 'usuarios',      'updated_at',     'TEXT');       // DT-NUEVA-B
 
-    db.prepare(`
-      UPDATE categorias
-      SET updated_at = datetime('now')
-      WHERE updated_at IS NULL
-    `).run();
-
-    db.prepare(`
-      UPDATE productos
-      SET updated_at = COALESCE(creado_en, datetime('now'))
-      WHERE updated_at IS NULL
-    `).run();
-
-    db.prepare(`
-      UPDATE stock_sucursal
-      SET updated_at = COALESCE(actualizado_en, datetime('now'))
-      WHERE updated_at IS NULL
-    `).run();
+    db.prepare(`UPDATE categorias   SET updated_at = datetime('now')                  WHERE updated_at IS NULL`).run();
+    db.prepare(`UPDATE productos    SET updated_at = COALESCE(creado_en, datetime('now')) WHERE updated_at IS NULL`).run();
+    db.prepare(`UPDATE stock_sucursal SET updated_at = COALESCE(actualizado_en, datetime('now')) WHERE updated_at IS NULL`).run();
+    db.prepare(`UPDATE proveedores  SET updated_at = COALESCE(creado_en, datetime('now')) WHERE updated_at IS NULL`).run();
+    db.prepare(`UPDATE usuarios     SET updated_at = COALESCE(creado_en, datetime('now')) WHERE updated_at IS NULL`).run();
 
     db.exec(`
       CREATE TRIGGER IF NOT EXISTS categorias_touch_updated_at
@@ -613,6 +606,22 @@
         SET updated_at = datetime('now'),
             actualizado_en = datetime('now')
         WHERE id = OLD.id;
+      END;
+
+      CREATE TRIGGER IF NOT EXISTS proveedores_touch_updated_at
+      AFTER UPDATE ON proveedores
+      FOR EACH ROW
+      WHEN NEW.updated_at = OLD.updated_at
+      BEGIN
+        UPDATE proveedores SET updated_at = datetime('now') WHERE id = OLD.id;
+      END;
+
+      CREATE TRIGGER IF NOT EXISTS usuarios_touch_updated_at
+      AFTER UPDATE ON usuarios
+      FOR EACH ROW
+      WHEN NEW.updated_at = OLD.updated_at
+      BEGIN
+        UPDATE usuarios SET updated_at = datetime('now') WHERE id = OLD.id;
       END;
     `);
   }

--- a/apps/server/src/adapters/db/sqlite/sqlite.schema.sql
+++ b/apps/server/src/adapters/db/sqlite/sqlite.schema.sql
@@ -24,7 +24,8 @@ CREATE TABLE IF NOT EXISTS usuarios (
   rol TEXT NOT NULL,
   activo INTEGER NOT NULL DEFAULT 1,
   creado_en TEXT NOT NULL DEFAULT (datetime('now')),
-  last_synced_at TEXT
+  last_synced_at TEXT,
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
 
@@ -52,6 +53,7 @@ CREATE TABLE IF NOT EXISTS stock_sucursal (
   sucursal_id INTEGER NOT NULL REFERENCES sucursales(id),
   cantidad INTEGER NOT NULL DEFAULT 0,
   minimo INTEGER NOT NULL DEFAULT 0,
+  stock_reservado INTEGER NOT NULL DEFAULT 0,
   actualizado_en TEXT NOT NULL DEFAULT (datetime('now')),
   updated_at TEXT NOT NULL DEFAULT (datetime('now')),
   UNIQUE(producto_id, sucursal_id)
@@ -91,7 +93,8 @@ CREATE TABLE IF NOT EXISTS proveedores (
   email TEXT,
   direccion TEXT,
   activo INTEGER NOT NULL DEFAULT 1,
-  creado_en TEXT NOT NULL DEFAULT (datetime('now'))
+  creado_en TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
 CREATE TABLE IF NOT EXISTS recepciones_mercancia (

--- a/apps/server/src/adapters/sync/snapshot.service.ts
+++ b/apps/server/src/adapters/sync/snapshot.service.ts
@@ -110,8 +110,8 @@ export async function bootstrapSnapshot(sucursalId: number): Promise<SnapshotCou
     `);
     const stmtStock = db.prepare(`
       INSERT OR REPLACE INTO stock_sucursal
-        (producto_id, sucursal_id, cantidad, minimo, updated_at)
-      VALUES (?, ?, ?, ?, ?)
+        (producto_id, sucursal_id, cantidad, minimo, stock_reservado, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?)
     `);
     for (const p of productos) {
       stmtProd.run(
@@ -123,7 +123,7 @@ export async function bootstrapSnapshot(sucursalId: number): Promise<SnapshotCou
       );
       const stockRow = p.stocks[0];
       if (stockRow) {
-        stmtStock.run(p.id, sucursalId, stockRow.cantidad, stockRow.minimo, stockRow.updatedAt.toISOString());
+        stmtStock.run(p.id, sucursalId, stockRow.cantidad, stockRow.minimo, stockRow.stockReservado, stockRow.updatedAt.toISOString());
       }
     }
     if (productos.length > 0) {
@@ -136,27 +136,29 @@ export async function bootstrapSnapshot(sucursalId: number): Promise<SnapshotCou
     // ── Usuarios (con hash para login offline — T-07F) ────────────────────
     const stmtUser = db.prepare(`
       INSERT OR REPLACE INTO usuarios
-        (id, sucursal_id, nombre, email, contrasena_hash, rol, activo, last_synced_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        (id, sucursal_id, nombre, email, contrasena_hash, rol, activo, last_synced_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
     for (const u of usuarios) {
       stmtUser.run(
         u.id, u.sucursalId ?? null, u.nombre, u.email,
         u.contrasenaHash, u.rol, u.activo ? 1 : 0,
         now.toISOString(),
+        u.updatedAt.toISOString(),
       );
     }
 
     // ── GAP-2: Proveedores + GAP-4 ────────────────────────────────────────
     const stmtProv = db.prepare(`
-      INSERT OR REPLACE INTO proveedores (id, nombre, nit, telefono, email, direccion, activo, creado_en)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT OR REPLACE INTO proveedores (id, nombre, nit, telefono, email, direccion, activo, creado_en, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
     for (const p of proveedores) {
       stmtProv.run(
         p.id, p.nombre, p.nit ?? null, p.telefono ?? null,
         p.email ?? null, p.direccion ?? null, p.activo ? 1 : 0,
         p.creadoEn.toISOString(),
+        p.updatedAt.toISOString(),
       );
     }
     if (proveedores.length > 0) {
@@ -244,19 +246,15 @@ export async function refreshSnapshot(sucursalId: number): Promise<SnapshotCount
 
   const now   = new Date();
 
-  // BUG-NUEVO-D: usuarios no tiene updatedAt → siempre re-sincronizar TODOS los
-  // usuarios de la sucursal para que desactivaciones propaguen en ≤5 min.
-  // Las tablas con updatedAt siguen el camino delta normal.
+  // DT-NUEVA-B resuelto: proveedores y usuarios ahora tienen updatedAt → delta real.
   const [categorias, productos, proveedores, facturas, recepciones, usuarios] =
     await Promise.all([
-      // updatedAt cubre CREATE y UPDATE en categorias y productos
       prisma.categoria.findMany({ where: { updatedAt: { gte: since } } }),
       prisma.producto.findMany({
         where:   { updatedAt: { gte: since } },
         include: { stocks: { where: { sucursalId } } },
       }),
-      // proveedores no tiene updatedAt → filtrar por creadoEn (solo nuevos)
-      prisma.proveedor.findMany({ where: { creadoEn: { gte: since } } }),
+      prisma.proveedor.findMany({ where: { updatedAt: { gte: since } } }),
       prisma.facturaDte.findMany({
         where:   { sucursalId, creadoEn: { gte: since } },
         include: { detalles: true },
@@ -265,8 +263,7 @@ export async function refreshSnapshot(sucursalId: number): Promise<SnapshotCount
         where:   { sucursalId, creadoEn: { gte: since } },
         include: { detalles: true },
       }),
-      // Siempre todos los usuarios de la sucursal (sin filtro por fecha)
-      prisma.usuario.findMany({ where: { sucursalId } }),
+      prisma.usuario.findMany({ where: { sucursalId, updatedAt: { gte: since } } }),
     ]);
 
   const hayDelta = categorias.length > 0 || productos.length > 0 || usuarios.length > 0
@@ -297,8 +294,8 @@ export async function refreshSnapshot(sucursalId: number): Promise<SnapshotCount
     `);
     const stmtStock = db.prepare(`
       INSERT OR REPLACE INTO stock_sucursal
-        (producto_id, sucursal_id, cantidad, minimo, updated_at)
-      VALUES (?, ?, ?, ?, ?)
+        (producto_id, sucursal_id, cantidad, minimo, stock_reservado, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?)
     `);
     for (const p of productos) {
       stmtProd.run(
@@ -310,41 +307,36 @@ export async function refreshSnapshot(sucursalId: number): Promise<SnapshotCount
       );
       const stockRow = p.stocks[0];
       if (stockRow) {
-        stmtStock.run(p.id, sucursalId, stockRow.cantidad, stockRow.minimo, stockRow.updatedAt.toISOString());
+        stmtStock.run(p.id, sucursalId, stockRow.cantidad, stockRow.minimo, stockRow.stockReservado, stockRow.updatedAt.toISOString());
       }
     }
 
-    // ── Usuarios: re-sync completo + GAP-4 para propagar desactivaciones ──
+    // ── Usuarios: delta por updatedAt (DT-NUEVA-B resuelto) ───────────────
     const stmtUser = db.prepare(`
       INSERT OR REPLACE INTO usuarios
-        (id, sucursal_id, nombre, email, contrasena_hash, rol, activo, last_synced_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        (id, sucursal_id, nombre, email, contrasena_hash, rol, activo, last_synced_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
     for (const u of usuarios) {
       stmtUser.run(
         u.id, u.sucursalId ?? null, u.nombre, u.email,
         u.contrasenaHash, u.rol, u.activo ? 1 : 0,
         now.toISOString(),
+        u.updatedAt.toISOString(),
       );
     }
-    // GAP-4 para usuarios: desactivar en SQLite los que ya no existen/están activos en nube
-    if (usuarios.length > 0) {
-      const ph  = usuarios.map(() => '?').join(',');
-      const ids = usuarios.map(u => u.id);
-      db.prepare(`UPDATE usuarios SET activo = 0 WHERE sucursal_id = ? AND id NOT IN (${ph}) AND activo = 1`)
-        .run(sucursalId, ...ids);
-    }
 
-    // ── GAP-2: Proveedores nuevos ─────────────────────────────────────────
+    // ── GAP-2: Proveedores nuevos y modificados (DT-NUEVA-B resuelto) ─────
     const stmtProv = db.prepare(`
-      INSERT OR REPLACE INTO proveedores (id, nombre, nit, telefono, email, direccion, activo, creado_en)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT OR REPLACE INTO proveedores (id, nombre, nit, telefono, email, direccion, activo, creado_en, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
     for (const p of proveedores) {
       stmtProv.run(
         p.id, p.nombre, p.nit ?? null, p.telefono ?? null,
         p.email ?? null, p.direccion ?? null, p.activo ? 1 : 0,
         p.creadoEn.toISOString(),
+        p.updatedAt.toISOString(),
       );
     }
 

--- a/apps/server/src/adapters/sync/sync-operation-handler.ts
+++ b/apps/server/src/adapters/sync/sync-operation-handler.ts
@@ -23,14 +23,14 @@ const CAMPOS_ESCALARES: Record<string, string[]> = {
   ],
   categoria: ['id', 'nombre', 'descripcion', 'activo', 'updatedAt'],
   // BUG-A03: campo correcto en Prisma es 'contrasenaHash', no 'passwordHash'
-  usuario: ['id', 'nombre', 'email', 'contrasenaHash', 'rol', 'sucursalId', 'activo'],
-  stockSucursal: ['id', 'productoId', 'sucursalId', 'cantidad', 'minimo', 'actualizadoEn', 'updatedAt'],
+  usuario: ['id', 'nombre', 'email', 'contrasenaHash', 'rol', 'sucursalId', 'activo', 'updatedAt'],
+  stockSucursal: ['id', 'productoId', 'sucursalId', 'cantidad', 'minimo', 'stockReservado', 'actualizadoEn', 'updatedAt'],
   facturaDte: [
     'id', 'sucursalId', 'usuarioId', 'codigoGeneracion', 'numeroControl', 'tipoDte',
     'clienteNombre', 'totalSinIva', 'iva', 'total', 'dteJson', 'estado', 'sincronizado', 'creadoEn',
   ],
   detalleVenta: ['id', 'facturaId', 'productoId', 'cantidad', 'precioUnit', 'subtotal'],
-  proveedor: ['id', 'nombre', 'nit', 'telefono', 'email', 'direccion', 'activo', 'creadoEn'],
+  proveedor: ['id', 'nombre', 'nit', 'telefono', 'email', 'direccion', 'activo', 'creadoEn', 'updatedAt'],
   recepcionMercancia: [
     'id', 'proveedorId', 'sucursalId', 'usuarioId', 'numeroFactura', 'total', 'observaciones', 'creadoEn',
   ],


### PR DESCRIPTION
Deuda Tecnica: stockReservado ausente en SQLite y sync
·	sqlite.schema.sql: columna stock_reservado en stock_sucursal
·	sqlite.client.ts: ensureColumn + trigger + query + mapper
·	sync-operation-handler.ts: stockReservado en CAMPOS_ESCALARES
·	snapshot.service.ts: stock_reservado en upserts bootstrap y refresh
Deuda Tecnica: Proveedor y Usuario sin updatedAt para delta sync
·	schema.prisma: @updatedAt en Proveedor y Usuario
·	migration.sql: ALTER TABLE updated_at en proveedores y usuarios
·	sqlite.client.ts: ensureColumn + triggers para ambas tablas
·	sync-operation-handler.ts: updatedAt en CAMPOS_ESCALARES de proveedor y usuario
·	snapshot.service.ts: delta real por updatedAt (elimina re-sync-all de usuarios)
Fix migración T-16.1: seed INSERT zonas_envio usa NULL en lugar de sucursal_id=1 para que la shadow database de Prisma no falle con FK violation