### PR TITLE
feat(HU-19): integra Stripe PaymentIntents, webhook y 

### DIFF
--- a/apps/server/src/adapters/alertas/alertas.service.ts
+++ b/apps/server/src/adapters/alertas/alertas.service.ts
@@ -3,8 +3,8 @@
  * T-03.1: Job automatico revision de stock cada 60 minutos
  * T-03.2: Envio de correo con Nodemailer
  */
-import nodemailer from 'nodemailer';
 import { prisma } from '../db/prisma/prisma.client';
+import { crearTransporte } from '../email/email.service';
 
 const INTERVALO_MS = 60 * 60 * 1000;  // 60 minutos
 const ANTI_SPAM_MS = 60 * 60 * 1000;  // no re-alertar en 1 hora
@@ -43,18 +43,6 @@ async function initAntiSpam(): Promise<void> {
   }
 }
 
-function crearTransporte() {
-  if (process.env.SMTP_HOST && process.env.SMTP_USER && process.env.SMTP_PASS) {
-    return nodemailer.createTransport({
-      host:   process.env.SMTP_HOST,
-      port:   Number(process.env.SMTP_PORT ?? 587),
-      secure: process.env.SMTP_SECURE === 'true',
-      auth: { user: process.env.SMTP_USER, pass: process.env.SMTP_PASS },
-    });
-  }
-  console.warn('[Alertas] SMTP no configurado — modo simulado activo');
-  return null;
-}
 
 async function getEmailBodeguero(sucursalId: number): Promise<string | null> {
   const bodeguero = await prisma.usuario.findFirst({

--- a/apps/server/src/adapters/email/email.service.ts
+++ b/apps/server/src/adapters/email/email.service.ts
@@ -1,0 +1,95 @@
+// T-19.5 / T-03.2: Servicio de correo compartido — alertas de stock y confirmaciones de pago.
+import nodemailer from 'nodemailer';
+import { env } from '../../config/env';
+
+export function crearTransporte() {
+  if (env.smtp.host && env.smtp.user && env.smtp.pass) {
+    return nodemailer.createTransport({
+      host:   env.smtp.host,
+      port:   env.smtp.port,
+      secure: env.smtp.secure,
+      auth: { user: env.smtp.user, pass: env.smtp.pass },
+    });
+  }
+  console.warn('[Email] SMTP no configurado — modo simulado activo');
+  return null;
+}
+
+function escapeHtml(text: string): string {
+  return text.replace(/[&<>"']/g, (c) =>
+    ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#039;' })[c] ?? c
+  );
+}
+
+// Anti-spam para confirmaciones de pago: no reenviar si ya se envió en 10 min
+const ultimaConfirmacion = new Map<number, number>();
+const ANTI_SPAM_PAGO_MS = 10 * 60 * 1000;
+
+export interface ConfirmacionPagoParams {
+  clienteEmail:  string;
+  clienteNombre: string;
+  pedidoId:      number;
+  productos:     Array<{ nombre: string; cantidad: number; precioUnit: number }>;
+  monto:         number;
+  metodo:        string;
+  transactionId: string;
+}
+
+export async function enviarEmailConfirmacionPago(params: ConfirmacionPagoParams): Promise<void> {
+  const ultimo = ultimaConfirmacion.get(params.pedidoId) ?? 0;
+  if (Date.now() - ultimo < ANTI_SPAM_PAGO_MS) return;
+
+  const transporte = crearTransporte();
+  if (!transporte) return;
+
+  const filas = params.productos.map(p => `
+    <tr>
+      <td style="padding:8px 12px;border-bottom:1px solid #e5e7eb">${escapeHtml(p.nombre)}</td>
+      <td style="padding:8px 12px;text-align:center;border-bottom:1px solid #e5e7eb">${p.cantidad}</td>
+      <td style="padding:8px 12px;text-align:right;border-bottom:1px solid #e5e7eb">$${(p.cantidad * p.precioUnit).toFixed(2)}</td>
+    </tr>`).join('');
+
+  const html = `
+    <div style="font-family:Arial,sans-serif;max-width:600px;margin:0 auto">
+      <div style="background:#1f2937;padding:20px;border-radius:8px 8px 0 0">
+        <h1 style="color:white;margin:0;font-size:20px">Confirmacion de Pago</h1>
+        <p style="color:#9ca3af;margin:4px 0 0">FERRED — Pedido #${params.pedidoId}</p>
+      </div>
+      <div style="background:#f9fafb;padding:20px;border:1px solid #e5e7eb;border-top:none;border-radius:0 0 8px 8px">
+        <p>Hola <strong>${escapeHtml(params.clienteNombre)}</strong>, tu pago fue procesado exitosamente.</p>
+        <table style="width:100%;border-collapse:collapse;background:white;border:1px solid #e5e7eb;margin:16px 0">
+          <thead>
+            <tr style="background:#1f2937;color:white">
+              <th style="padding:10px;text-align:left">Producto</th>
+              <th style="padding:10px;text-align:center">Cant.</th>
+              <th style="padding:10px;text-align:right">Subtotal</th>
+            </tr>
+          </thead>
+          <tbody>${filas}</tbody>
+          <tfoot>
+            <tr style="background:#f3f4f6">
+              <td colspan="2" style="padding:10px 12px;font-weight:bold;text-align:right">Total:</td>
+              <td style="padding:10px 12px;font-weight:bold;text-align:right">$${params.monto.toFixed(2)}</td>
+            </tr>
+          </tfoot>
+        </table>
+        <table style="width:100%;font-size:14px;color:#374151">
+          <tr><td style="padding:4px 0"><strong>Metodo:</strong></td><td>${escapeHtml(params.metodo)}</td></tr>
+          <tr><td style="padding:4px 0"><strong>Referencia:</strong></td><td style="font-family:monospace">${escapeHtml(params.transactionId)}</td></tr>
+        </table>
+        <p style="color:#6b7280;font-size:12px;margin-top:16px">Guarda este correo como comprobante de tu compra.</p>
+      </div>
+    </div>`;
+
+  try {
+    await transporte.sendMail({
+      from:    `"FERRED" <${env.smtp.user}>`,
+      to:      params.clienteEmail,
+      subject: `Confirmacion de pago — Pedido #${params.pedidoId}`,
+      html,
+    });
+    ultimaConfirmacion.set(params.pedidoId, Date.now());
+  } catch (err: unknown) {
+    console.error('[Email] Error al enviar confirmacion de pago:', (err as Error).message);
+  }
+}

--- a/apps/server/src/adapters/http/routes/pagos.routes.ts
+++ b/apps/server/src/adapters/http/routes/pagos.routes.ts
@@ -15,6 +15,7 @@ import {
 import { roleMiddleware } from '../middleware/role.middleware';
 import { assertSameSucursal } from '../middleware/sucursal.guard';
 import { OfflineCache } from '../../sync/sync.service';
+import { createPaymentIntent } from '../../payment/payment.service';
 
 const MAX_COMPROBANTE_BYTES = 2 * 1024 * 1024;
 const COMPROBANTES_DIR = path.resolve(process.cwd(), 'uploads', 'comprobantes');
@@ -228,4 +229,49 @@ pagosRoutes.get('/comprobante/:archivo', authenticatePago, authorizeComprobanteR
 
     return next(error);
   });
+});
+
+// T-19.2: Crea un PaymentIntent de Stripe y devuelve el clientSecret al frontend.
+// Pacheco usa este clientSecret para inicializar Stripe Elements en PagoPage.tsx.
+pagosRoutes.post('/crear-intent', authenticatePago, async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const pedidoId = Number(req.body.pedidoId);
+    if (!Number.isInteger(pedidoId) || pedidoId < 1) {
+      return res.status(400).json({ error: 'pedidoId invalido' });
+    }
+
+    const pedido = await prisma.pedidoOnline.findUnique({
+      where:  { id: pedidoId },
+      select: { id: true, total: true, estado: true, clienteId: true, sucursalId: true },
+    });
+
+    if (!pedido) return res.status(404).json({ error: 'Pedido no encontrado' });
+    if (pedido.estado === 'CANCELADO') {
+      return res.status(409).json({ error: 'El pedido esta cancelado' });
+    }
+
+    // Verificar que el cliente que llama sea el dueño del pedido (si es cliente ecommerce)
+    if (req.cliente && pedido.clienteId !== req.cliente.id) {
+      return res.status(404).json({ error: 'Pedido no encontrado' });
+    }
+
+    const pagoValidado = await prisma.pago.findFirst({
+      where:  { pedidoId, estado: 'VALIDADO' },
+      select: { id: true },
+    });
+    if (pagoValidado) {
+      return res.status(409).json({ error: 'El pedido ya tiene un pago aprobado' });
+    }
+
+    const { clientSecret, paymentIntentId } = await createPaymentIntent(pedidoId, pedido.total);
+
+    return res.json({ ok: true, clientSecret, paymentIntentId });
+  } catch (err) {
+    return next(err);
+  }
+});
+
+// Expone la clave publicable de Stripe al frontend sin necesidad de hardcodearla en el bundle.
+pagosRoutes.get('/stripe-public-key', (_req: Request, res: Response) => {
+  res.json({ publicKey: env.payment.publicKey });
 });

--- a/apps/server/src/adapters/http/routes/webhook.routes.ts
+++ b/apps/server/src/adapters/http/routes/webhook.routes.ts
@@ -1,0 +1,111 @@
+// T-19.3: Webhook de Stripe — recibe payment_intent.succeeded / payment_intent.payment_failed.
+// Montado ANTES de express.json() en index.ts para que el body llegue sin parsear.
+import { Router, Request, Response } from 'express';
+import type Stripe from 'stripe';
+import { prisma }                    from '../../db/prisma/prisma.client';
+import { stripe, construirEventoStripe } from '../../payment/payment.service';
+import { enviarEmailConfirmacionPago } from '../../email/email.service';
+
+export const stripeWebhookRoutes = Router();
+
+stripeWebhookRoutes.post('/', async (req: Request, res: Response) => {
+  const signature = req.headers['stripe-signature'];
+  if (!signature || typeof signature !== 'string') {
+    return res.status(400).json({ error: 'Firma de webhook requerida' });
+  }
+
+  let evento: ReturnType<typeof stripe.webhooks.constructEvent>;
+  try {
+    evento = construirEventoStripe(req.body as Buffer, signature);
+  } catch (err: unknown) {
+    console.error('[Webhook] Firma invalida:', (err as Error).message);
+    return res.status(400).json({ error: 'Firma invalida' });
+  }
+
+  try {
+    const pi = evento.data.object as Stripe.PaymentIntent;
+    if (evento.type === 'payment_intent.succeeded') {
+      await manejarPagoExitoso(pi);
+    } else if (evento.type === 'payment_intent.payment_failed') {
+      await manejarPagoFallido(pi);
+    }
+    // Otros eventos de Stripe se ignoran silenciosamente
+  } catch (err: unknown) {
+    console.error('[Webhook] Error procesando evento:', (err as Error).message);
+    // Retornamos 200 igual para que Stripe no reintente indefinidamente errores de lógica
+  }
+
+  return res.json({ received: true });
+});
+
+async function manejarPagoExitoso(pi: Stripe.PaymentIntent): Promise<void> {
+  const pedidoId = Number(pi.metadata?.pedidoId);
+  if (!pedidoId) return;
+
+  const pedido = await prisma.pedidoOnline.findUnique({
+    where:   { id: pedidoId },
+    include: {
+      detalles: {
+        include: { producto: { select: { nombre: true } } },
+      },
+      cliente: { select: { email: true, nombre: true } },
+    },
+  });
+  if (!pedido) return;
+
+  const monto = pi.amount_received / 100;
+
+  // Idempotencia: upsert por (pedidoId, estado='VALIDADO') — la constraint unique lo garantiza
+  await prisma.pago.upsert({
+    where:  { pago_pedido_validado_unique: { pedidoId, estado: 'VALIDADO' } },
+    update: {},
+    create: {
+      pedidoId,
+      metodo:     'STRIPE',
+      referencia: pi.id,
+      monto,
+      estado:     'VALIDADO',
+      validadoEn: new Date(),
+    },
+  });
+
+  // Notificar al cliente por email si tenemos su correo
+  const clienteEmail  = pedido.cliente?.email;
+  const clienteNombre = pedido.cliente?.nombre ?? pedido.clienteNombre ?? 'Cliente';
+
+  if (clienteEmail) {
+    await enviarEmailConfirmacionPago({
+      clienteEmail,
+      clienteNombre,
+      pedidoId,
+      productos: pedido.detalles.map(d => ({
+        nombre:     d.producto.nombre,
+        cantidad:   Number(d.cantidad),
+        precioUnit: d.precioUnit,
+      })),
+      monto,
+      metodo:        'Stripe',
+      transactionId: pi.id,
+    });
+  }
+}
+
+async function manejarPagoFallido(pi: Stripe.PaymentIntent): Promise<void> {
+  const pedidoId = Number(pi.metadata?.pedidoId);
+  if (!pedidoId) return;
+
+  const motivo = pi.last_payment_error?.message ?? 'Pago rechazado por la pasarela';
+
+  await prisma.pago.upsert({
+    where:  { pago_pedido_validado_unique: { pedidoId, estado: 'RECHAZADO' } },
+    update: { motivoRechazo: motivo },
+    create: {
+      pedidoId,
+      metodo:        'STRIPE',
+      referencia:    pi.id,
+      monto:         pi.amount / 100,
+      estado:        'RECHAZADO',
+      motivoRechazo: motivo,
+    },
+  });
+}

--- a/apps/server/src/adapters/payment/payment.service.ts
+++ b/apps/server/src/adapters/payment/payment.service.ts
@@ -1,0 +1,36 @@
+// T-19.2: Servicio de pagos con Stripe PaymentIntents.
+// El pedidoId viaja en metadata del PaymentIntent para que el webhook lo recupere sin BD extra.
+import Stripe from 'stripe';
+import { env } from '../../config/env';
+
+const stripe = new Stripe(env.payment.secretKey, { apiVersion: '2026-04-22.dahlia' });
+
+export { stripe };
+
+export interface PaymentIntentResult {
+  clientSecret:    string;
+  paymentIntentId: string;
+}
+
+// Crea un PaymentIntent en Stripe. monto en USD (dolares, no centavos).
+export async function createPaymentIntent(
+  pedidoId: number,
+  monto:    number,
+): Promise<PaymentIntentResult> {
+  const pi = await stripe.paymentIntents.create({
+    amount:   Math.round(monto * 100), // Stripe usa centavos
+    currency: 'usd',
+    metadata: { pedidoId: String(pedidoId) },
+    automatic_payment_methods: { enabled: true },
+  });
+
+  if (!pi.client_secret) throw new Error('Stripe no retornó client_secret');
+
+  return { clientSecret: pi.client_secret, paymentIntentId: pi.id };
+}
+
+// Verifica la firma del webhook y retorna el evento de Stripe.
+// rawBody debe ser el Buffer/string del cuerpo sin parsear.
+export function construirEventoStripe(rawBody: Buffer, signature: string): ReturnType<typeof stripe.webhooks.constructEvent> {
+  return stripe.webhooks.constructEvent(rawBody, signature, env.payment.webhookSecret);
+}

--- a/apps/server/src/config/env.ts
+++ b/apps/server/src/config/env.ts
@@ -69,4 +69,20 @@ export const env = {
     // T-07F.3: días máximos sin sincronizar antes de rechazar login offline
     authMaxDays: Number(process.env.OFFLINE_AUTH_MAX_DAYS ?? 30),
   },
+
+  // T-19.1: Stripe — secretKey requerida; publicKey expuesta al frontend vía endpoint
+  payment: {
+    secretKey:    required('STRIPE_SECRET_KEY'),
+    webhookSecret: required('STRIPE_WEBHOOK_SECRET'),
+    publicKey:    process.env.STRIPE_PUBLISHABLE_KEY ?? '',
+  },
+
+  // T-19.5 / T-03.2: Nodemailer — opcional; sin vars → modo simulado (solo consola)
+  smtp: {
+    host:   process.env.SMTP_HOST,
+    port:   Number(process.env.SMTP_PORT ?? 587),
+    secure: process.env.SMTP_SECURE === 'true',
+    user:   process.env.SMTP_USER,
+    pass:   process.env.SMTP_PASS,
+  },
 } as const;

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -30,10 +30,11 @@ import { errorMiddleware }  from './adapters/http/middleware/error.middleware';
 import { jwtMiddleware }    from './adapters/http/middleware/jwt.middleware';
 import { SyncService }      from './adapters/sync/sync.service';
 import { SnapshotService }  from './adapters/sync/snapshot.service';
-import { syncRoutes }       from './adapters/http/routes/sync.routes';
-import { reportesRoutes }   from './adapters/http/routes/reportes.routes';
-import { initSqlite }       from './adapters/db/sqlite/sqlite.client';
-import { contarPendientes } from './adapters/sync/sync.local';
+import { syncRoutes }           from './adapters/http/routes/sync.routes';
+import { reportesRoutes }       from './adapters/http/routes/reportes.routes';
+import { stripeWebhookRoutes }  from './adapters/http/routes/webhook.routes';
+import { initSqlite }           from './adapters/db/sqlite/sqlite.client';
+import { contarPendientes }     from './adapters/sync/sync.local';
 
 try { initSqlite(); } catch (e) { console.warn('[sqlite] Modo offline no disponible:', (e as Error).message); }
 
@@ -41,6 +42,10 @@ const app = express();
 const branchId = process.env.BRANCH_ID || '1';
 
 app.use(helmet());
+
+// T-19.3: El webhook de Stripe necesita el body SIN parsear para verificar la firma.
+// Debe montarse ANTES de express.json() — de lo contrario la verificación de firma falla.
+app.use('/api/pagos/webhook', express.raw({ type: 'application/json' }), stripeWebhookRoutes);
 
 const ALLOWED_ORIGINS = [
   'https://ferred.netlify.app',


### PR DESCRIPTION
email de confirmación

- Crea payment.service.ts con createPaymentIntent y verificacion de firma. 
- Expone POST /api/pagos/crear-intent y GET /api/pagos/stripe-public-key. 
- Webhook en /api/pagos/webhook maneja succeeded/failed con upsert idempotente via @@unique([pedidoId, estado]); montado con express.raw antes de express.json. 
- Extrae email.service.ts como servicio compartido con deduplicacion por pedidoId; alertas.service.ts reutiliza crearTransporte. 
- Agrega bloques payment y smtp a env.ts.