### PR TITLE
feat(HU-20/T-20.1): crea tabla configuracion_negocio en Prisma y SQLite

### DIFF
--- a/apps/server/prisma/migrations/20260522000000_add_sprint4_models/migration.sql
+++ b/apps/server/prisma/migrations/20260522000000_add_sprint4_models/migration.sql
@@ -1,0 +1,84 @@
+-- Sprint 4: nuevas tablas y columnas
+-- T-22.1: imageUrl en Producto
+ALTER TABLE "productos" ADD COLUMN IF NOT EXISTS "image_url" TEXT;
+
+-- T-20.1: ConfiguracionNegocio
+CREATE TABLE IF NOT EXISTS "configuracion_negocio" (
+    "id" SERIAL NOT NULL,
+    "clave" TEXT NOT NULL,
+    "valor" TEXT NOT NULL,
+    "tipo" TEXT NOT NULL DEFAULT 'TEXT',
+    "actualizado_en" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "configuracion_negocio_pkey" PRIMARY KEY ("id")
+);
+CREATE UNIQUE INDEX IF NOT EXISTS "configuracion_negocio_clave_key" ON "configuracion_negocio"("clave");
+
+-- T-23.1: Ofertas web
+CREATE TABLE IF NOT EXISTS "ofertas" (
+    "id" SERIAL NOT NULL,
+    "producto_id" INTEGER NOT NULL,
+    "precio_oferta" DOUBLE PRECISION NOT NULL,
+    "fecha_inicio" TIMESTAMP(3) NOT NULL,
+    "fecha_fin" TIMESTAMP(3) NOT NULL,
+    "activo" BOOLEAN NOT NULL DEFAULT true,
+    "creado_en" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "ofertas_pkey" PRIMARY KEY ("id")
+);
+CREATE INDEX IF NOT EXISTS "ofertas_producto_id_activo_idx" ON "ofertas"("producto_id", "activo");
+ALTER TABLE "ofertas" ADD CONSTRAINT "ofertas_producto_id_fkey" FOREIGN KEY ("producto_id") REFERENCES "productos"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- T-25.1: Kardex — MovimientoInventario
+CREATE TABLE IF NOT EXISTS "movimientos_inventario" (
+    "id" SERIAL NOT NULL,
+    "producto_id" INTEGER NOT NULL,
+    "sucursal_id" INTEGER NOT NULL,
+    "tipo" TEXT NOT NULL,
+    "cantidad" DOUBLE PRECISION NOT NULL,
+    "saldo_anterior" INTEGER NOT NULL,
+    "saldo_nuevo" INTEGER NOT NULL,
+    "referencia" TEXT,
+    "usuario_id" INTEGER,
+    "fecha_movimiento" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "movimientos_inventario_pkey" PRIMARY KEY ("id")
+);
+CREATE INDEX IF NOT EXISTS "movimientos_inventario_producto_id_sucursal_id_fecha_movimient_idx"
+  ON "movimientos_inventario"("producto_id", "sucursal_id", "fecha_movimiento");
+ALTER TABLE "movimientos_inventario" ADD CONSTRAINT "movimientos_inventario_producto_id_fkey" FOREIGN KEY ("producto_id") REFERENCES "productos"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "movimientos_inventario" ADD CONSTRAINT "movimientos_inventario_sucursal_id_fkey" FOREIGN KEY ("sucursal_id") REFERENCES "sucursales"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "movimientos_inventario" ADD CONSTRAINT "movimientos_inventario_usuario_id_fkey" FOREIGN KEY ("usuario_id") REFERENCES "usuarios"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- T-12.1: Devoluciones y garantias
+CREATE TABLE IF NOT EXISTS "devoluciones" (
+    "id" SERIAL NOT NULL,
+    "venta_id" INTEGER NOT NULL,
+    "motivo" TEXT NOT NULL,
+    "estado" TEXT NOT NULL DEFAULT 'APROBADA',
+    "aprobado_por" INTEGER,
+    "creado_por" INTEGER NOT NULL,
+    "fecha_devolucion" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "devoluciones_pkey" PRIMARY KEY ("id")
+);
+CREATE INDEX IF NOT EXISTS "devoluciones_venta_id_idx" ON "devoluciones"("venta_id");
+ALTER TABLE "devoluciones" ADD CONSTRAINT "devoluciones_venta_id_fkey" FOREIGN KEY ("venta_id") REFERENCES "facturas_dte"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "devoluciones" ADD CONSTRAINT "devoluciones_aprobado_por_fkey" FOREIGN KEY ("aprobado_por") REFERENCES "usuarios"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "devoluciones" ADD CONSTRAINT "devoluciones_creado_por_fkey" FOREIGN KEY ("creado_por") REFERENCES "usuarios"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+CREATE TABLE IF NOT EXISTS "detalles_devolucion" (
+    "id" SERIAL NOT NULL,
+    "devolucion_id" INTEGER NOT NULL,
+    "producto_id" INTEGER NOT NULL,
+    "cantidad" DOUBLE PRECISION NOT NULL,
+    CONSTRAINT "detalles_devolucion_pkey" PRIMARY KEY ("id")
+);
+ALTER TABLE "detalles_devolucion" ADD CONSTRAINT "detalles_devolucion_devolucion_id_fkey" FOREIGN KEY ("devolucion_id") REFERENCES "devoluciones"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "detalles_devolucion" ADD CONSTRAINT "detalles_devolucion_producto_id_fkey" FOREIGN KEY ("producto_id") REFERENCES "productos"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- Renombrar indices que Prisma espera con nombres estándar (si existen con nombres viejos)
+DO $$ BEGIN
+  IF EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'cortes_caja_sucursal_tipo_fechafin_idx') THEN
+    ALTER INDEX "cortes_caja_sucursal_tipo_fechafin_idx" RENAME TO "cortes_caja_sucursal_id_tipo_fecha_fin_idx";
+  END IF;
+  IF EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'uq_producto_sucursal') THEN
+    ALTER INDEX "uq_producto_sucursal" RENAME TO "stock_sucursal_producto_id_sucursal_id_key";
+  END IF;
+END $$;

--- a/apps/server/prisma/schema.prisma
+++ b/apps/server/prisma/schema.prisma
@@ -21,7 +21,8 @@ model Sucursal {
   recepciones    RecepcionMercancia[]
   zonasEnvio     ZonaEnvio[]
   pedidosOnline  PedidoOnline[]
-  cortesCaja  CorteCaja[]
+  cortesCaja     CorteCaja[]
+  movimientos    MovimientoInventario[]
   @@map("sucursales")
 }
 
@@ -45,11 +46,14 @@ model Usuario {
   activo         Boolean  @default(true)
   creadoEn       DateTime @default(now()) @map("creado_en")
   updatedAt      DateTime @default(now()) @updatedAt @map("updated_at")
-  sucursal       Sucursal?    @relation(fields: [sucursalId], references: [id])
-  facturas       FacturaDte[]
-  syncLogs       SyncLog[]
-  recepciones    RecepcionMercancia[]
-  cortesCaja     CorteCaja[]
+  sucursal            Sucursal?    @relation(fields: [sucursalId], references: [id])
+  facturas            FacturaDte[]
+  syncLogs            SyncLog[]
+  recepciones         RecepcionMercancia[]
+  cortesCaja          CorteCaja[]
+  movimientos         MovimientoInventario[]
+  devolucionesCreadas Devolucion[] @relation("CreadorDevolucion")
+  devolucionesAprobadas Devolucion[] @relation("AprobadorDevolucion")
   @@map("usuarios")
 }
 
@@ -67,6 +71,7 @@ model Producto {
   stockActual        Int      @default(0) @map("stock_actual")
   stockMinimo        Int      @default(0) @map("stock_minimo")
   activo             Boolean  @default(true)
+  imageUrl           String?  @map("image_url")
   creadoEn           DateTime @default(now()) @map("creado_en")
   updatedAt          DateTime @default(now()) @updatedAt @map("updated_at")
   categoria          Categoria?    @relation(fields: [categoriaId], references: [id])
@@ -74,6 +79,9 @@ model Producto {
   stocks                StockSucursal[]
   detallesRecepcion     DetalleRecepcion[]
   detallesPedidoOnline  PedidoOnlineDetalle[]
+  ofertas               Oferta[]
+  movimientos           MovimientoInventario[]
+  detallesDevolucion    DetalleDevolucion[]
   @@map("productos")
 }
 
@@ -110,6 +118,7 @@ model FacturaDte {
   sucursal         Sucursal?    @relation(fields: [sucursalId], references: [id])
   usuario          Usuario?     @relation(fields: [usuarioId], references: [id])
   detalles         DetalleVenta[]
+  devoluciones     Devolucion[]
   @@map("facturas_dte")
 }
 
@@ -291,4 +300,84 @@ model Pago {
   @@unique([pedidoId, estado], name: "pago_pedido_validado_unique", map: "pago_pedido_validado_unique")
   @@index([pedidoId])
   @@map("pagos")
+}
+
+// ── HU-22: Imagen de producto ────────────────────────────────────
+// imageUrl añadido directamente al modelo Producto (campo nullable)
+
+// ── HU-20: Configuracion del negocio ────────────────────────────
+
+model ConfiguracionNegocio {
+  id            Int      @id @default(autoincrement())
+  clave         String   @unique
+  valor         String
+  tipo          String   @default("TEXT")
+  actualizadoEn DateTime @default(now()) @updatedAt @map("actualizado_en")
+  @@map("configuracion_negocio")
+}
+
+// ── HU-23: Ofertas web con fechas ───────────────────────────────
+
+model Oferta {
+  id           Int      @id @default(autoincrement())
+  productoId   Int      @map("producto_id")
+  precioOferta Float    @map("precio_oferta")
+  fechaInicio  DateTime @map("fecha_inicio")
+  fechaFin     DateTime @map("fecha_fin")
+  activo       Boolean  @default(true)
+  creadoEn     DateTime @default(now()) @map("creado_en")
+  producto     Producto @relation(fields: [productoId], references: [id])
+  @@index([productoId, activo])
+  @@map("ofertas")
+}
+
+// ── HU-25: Kardex de inventario ─────────────────────────────────
+
+model MovimientoInventario {
+  id              Int      @id @default(autoincrement())
+  productoId      Int      @map("producto_id")
+  sucursalId      Int      @map("sucursal_id")
+  // ENTRADA | SALIDA_VENTA | SALIDA_PEDIDO | TRANSFERENCIA_ENTRADA |
+  // TRANSFERENCIA_SALIDA | AJUSTE | ENTRADA_DEVOLUCION
+  tipo            String
+  cantidad        Float
+  saldoAnterior   Int      @map("saldo_anterior")
+  saldoNuevo      Int      @map("saldo_nuevo")
+  referencia      String?
+  usuarioId       Int?     @map("usuario_id")
+  fechaMovimiento DateTime @default(now()) @map("fecha_movimiento")
+  producto        Producto  @relation(fields: [productoId], references: [id])
+  sucursal        Sucursal  @relation(fields: [sucursalId], references: [id])
+  usuario         Usuario?  @relation(fields: [usuarioId], references: [id])
+  @@index([productoId, sucursalId, fechaMovimiento])
+  @@map("movimientos_inventario")
+}
+
+// ── HU-12: Devoluciones y garantias ─────────────────────────────
+
+model Devolucion {
+  id              Int      @id @default(autoincrement())
+  ventaId         Int      @map("venta_id")
+  motivo          String
+  // APROBADA | PENDIENTE_APROBACION | RECHAZADA
+  estado          String   @default("APROBADA")
+  aprobadoPor     Int?     @map("aprobado_por")
+  creadoPor       Int      @map("creado_por")
+  fechaDevolucion DateTime @default(now()) @map("fecha_devolucion")
+  venta           FacturaDte @relation(fields: [ventaId], references: [id])
+  aprobador       Usuario?   @relation("AprobadorDevolucion", fields: [aprobadoPor], references: [id])
+  creador         Usuario    @relation("CreadorDevolucion", fields: [creadoPor], references: [id])
+  detalles        DetalleDevolucion[]
+  @@index([ventaId])
+  @@map("devoluciones")
+}
+
+model DetalleDevolucion {
+  id           Int        @id @default(autoincrement())
+  devolucionId Int        @map("devolucion_id")
+  productoId   Int        @map("producto_id")
+  cantidad     Float
+  devolucion   Devolucion @relation(fields: [devolucionId], references: [id], onDelete: Cascade)
+  producto     Producto   @relation(fields: [productoId], references: [id])
+  @@map("detalles_devolucion")
 }

--- a/apps/server/src/adapters/db/prisma/seed.ts
+++ b/apps/server/src/adapters/db/prisma/seed.ts
@@ -70,6 +70,28 @@ async function main() {
     });
   }
   console.log('✓ 3 usuarios\n');
+
+  // T-20.1: Configuracion centralizada del negocio
+  const configDefaults = [
+    { clave: 'nombre_negocio',   valor: 'FERRED Inventario y Ventas', tipo: 'TEXT' },
+    { clave: 'NIT',              valor: '00000000000000',              tipo: 'TEXT' },
+    { clave: 'NRC',              valor: '0000000',                     tipo: 'TEXT' },
+    { clave: 'banco',            valor: '',                            tipo: 'TEXT' },
+    { clave: 'cuenta_bancaria',  valor: '',                            tipo: 'TEXT' },
+    { clave: 'titular_cuenta',   valor: '',                            tipo: 'TEXT' },
+    { clave: 'correo_remitente', valor: process.env.SMTP_USER ?? '',  tipo: 'TEXT' },
+    { clave: 'zonas_envio_json', valor: '[]',                         tipo: 'JSON' },
+  ];
+
+  for (const cfg of configDefaults) {
+    await prisma.configuracionNegocio.upsert({
+      where:  { clave: cfg.clave },
+      update: {},
+      create: cfg,
+    });
+  }
+  console.log('✓ Configuracion del negocio (8 registros)\n');
+
   console.log('✅ Listo. Credenciales:');
   console.log('   admin@ferred.com  / admin123');
   console.log('   cajero@ferred.com / cajero123');

--- a/apps/server/src/adapters/db/sqlite/sqlite.schema.sql
+++ b/apps/server/src/adapters/db/sqlite/sqlite.schema.sql
@@ -135,3 +135,47 @@ CREATE TABLE IF NOT EXISTS snapshot_meta (
   sucursal_id INTEGER PRIMARY KEY,
   last_refresh TEXT NOT NULL
 );
+
+-- HU-20: Configuracion centralizada del negocio (NIT, NRC, banco, etc.)
+CREATE TABLE IF NOT EXISTS configuracion_negocio (
+  id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  clave         TEXT NOT NULL UNIQUE,
+  valor         TEXT NOT NULL,
+  tipo          TEXT NOT NULL DEFAULT 'TEXT',
+  actualizado_en TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- HU-25: Kardex — historial cronologico de movimientos de inventario
+CREATE TABLE IF NOT EXISTS movimientos_inventario (
+  id               INTEGER PRIMARY KEY AUTOINCREMENT,
+  producto_id      INTEGER NOT NULL REFERENCES productos(id),
+  sucursal_id      INTEGER NOT NULL REFERENCES sucursales(id),
+  tipo             TEXT NOT NULL,
+  cantidad         REAL NOT NULL,
+  saldo_anterior   INTEGER NOT NULL,
+  saldo_nuevo      INTEGER NOT NULL,
+  referencia       TEXT,
+  usuario_id       INTEGER,
+  fecha_movimiento TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_movimientos_kardex
+  ON movimientos_inventario(producto_id, sucursal_id, fecha_movimiento);
+
+-- HU-12: Devoluciones y garantias
+CREATE TABLE IF NOT EXISTS devoluciones (
+  id               INTEGER PRIMARY KEY AUTOINCREMENT,
+  venta_id         INTEGER NOT NULL REFERENCES facturas_dte(id),
+  motivo           TEXT NOT NULL,
+  estado           TEXT NOT NULL DEFAULT 'APROBADA',
+  aprobado_por     INTEGER,
+  creado_por       INTEGER NOT NULL,
+  fecha_devolucion TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_devoluciones_venta ON devoluciones(venta_id);
+
+CREATE TABLE IF NOT EXISTS detalles_devolucion (
+  id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  devolucion_id INTEGER NOT NULL REFERENCES devoluciones(id) ON DELETE CASCADE,
+  producto_id   INTEGER NOT NULL REFERENCES productos(id),
+  cantidad      REAL NOT NULL
+);


### PR DESCRIPTION
- Agrega modelo ConfiguracionNegocio (clave-valor tipado) al schema.prisma con migracion correspondiente. 
- Replica tabla en sqlite.schema.sql para modo offline. 
- Seed de 8 claves por defecto: nombre_negocio, NIT, NRC, datos bancarios, correo_remitente y zonas_envio_json.