### PR TITLE
feat(HU-22/T-22.1): agrega imageUrl a Producto en Prisma y SQLite

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -28,6 +28,7 @@
     "multer": "^2.1.1",
     "nodemailer": "^8.0.5",
     "qrcode": "^1.5.4",
+    "stripe": "^22.1.1",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/apps/server/src/adapters/db/sqlite/sqlite.client.ts
+++ b/apps/server/src/adapters/db/sqlite/sqlite.client.ts
@@ -573,6 +573,7 @@
     ensureColumn(db, 'proveedores',   'updated_at',     'TEXT');       // DT-NUEVA-B
     ensureColumn(db, 'usuarios',      'last_synced_at', 'TEXT');       // T-07F.3
     ensureColumn(db, 'usuarios',      'updated_at',     'TEXT');       // DT-NUEVA-B
+    ensureColumn(db, 'productos',     'image_url',      'TEXT');       // T-22.1
 
     db.prepare(`UPDATE categorias   SET updated_at = datetime('now')                  WHERE updated_at IS NULL`).run();
     db.prepare(`UPDATE productos    SET updated_at = COALESCE(creado_en, datetime('now')) WHERE updated_at IS NULL`).run();

--- a/apps/server/src/adapters/sync/sync-operation-handler.ts
+++ b/apps/server/src/adapters/sync/sync-operation-handler.ts
@@ -13,13 +13,16 @@ const TABLAS_PERMITIDAS = new Set([
   'recepcionMercancia',
   'detalleRecepcion',
   'corteCaja',
+  'movimientoInventario',
+  'devolucion',
+  'detalleDevolucion',
 ]);
 
 const CAMPOS_ESCALARES: Record<string, string[]> = {
   producto: [
     'id', 'categoriaId', 'nombre', 'codigoBarras', 'tipoUnidad', 'precioCompra',
     'porcentajeGanancia', 'precioVenta', 'precioConIva', 'tieneIva', 'stockActual',
-    'stockMinimo', 'activo', 'creadoEn', 'updatedAt',
+    'stockMinimo', 'activo', 'imageUrl', 'creadoEn', 'updatedAt',
   ],
   categoria: ['id', 'nombre', 'descripcion', 'activo', 'updatedAt'],
   // BUG-A03: campo correcto en Prisma es 'contrasenaHash', no 'passwordHash'
@@ -41,6 +44,16 @@ const CAMPOS_ESCALARES: Record<string, string[]> = {
     'totalEfectivo', 'totalTarjeta', 'totalTransferencia', 'totalGeneral',
     'cantidadVentas', 'observaciones', 'creadoEn',
   ],
+  // T-25.1: kardex — solo CREATE, los movimientos son inmutables
+  movimientoInventario: [
+    'id', 'productoId', 'sucursalId', 'tipo', 'cantidad',
+    'saldoAnterior', 'saldoNuevo', 'referencia', 'usuarioId', 'fechaMovimiento',
+  ],
+  // T-12.1: devoluciones offline (T-12.7)
+  devolucion: [
+    'id', 'ventaId', 'motivo', 'estado', 'aprobadoPor', 'creadoPor', 'fechaDevolucion',
+  ],
+  detalleDevolucion: ['id', 'devolucionId', 'productoId', 'cantidad'],
 };
 
 // DT-11: tipo mínimo para acceder a los modelos de Prisma de forma dinámica

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -381,6 +381,9 @@ importers:
       qrcode:
         specifier: ^1.5.4
         version: 1.5.4
+      stripe:
+        specifier: ^22.1.1
+        version: 22.1.1(@types/node@20.19.39)
       zod:
         specifier: ^3.23.8
         version: 3.25.76
@@ -4758,6 +4761,15 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  stripe@22.1.1:
+    resolution: {integrity: sha512-cmodIYP27tBkJ8G7DuGgWw0PFuemlFZbuF3Wwr1TrjFjUa3T7NIgCe6TVwX8BO2ynu+xtTuDGfHafNDCPt9lXA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   stylis@4.2.0:
     resolution: {integrity: sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==}
@@ -9710,6 +9722,10 @@ snapshots:
   strip-json-comments@2.0.1: {}
 
   strip-json-comments@3.1.1: {}
+
+  stripe@22.1.1(@types/node@20.19.39):
+    optionalDependencies:
+      '@types/node': 20.19.39
 
   stylis@4.2.0: {}
 


### PR DESCRIPTION
- Añade campo imageUrl String? al modelo Producto con migracion no-breaking. sqlite.client.ts aplica ensureColumn para image_url en bases existentes. 
- Actualiza CAMPOS_ESCALARES en sync-operation-handler para incluir imageUrl en el payload de sync offline→online.