### PR TITLE
feat(server): completar T-23.2 y T-23.3 ofertas backend

### DIFF
--- a/apps/server/src/adapters/http/routes/oferta.routes.ts
+++ b/apps/server/src/adapters/http/routes/oferta.routes.ts
@@ -1,0 +1,238 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { z } from 'zod';
+import { prisma } from '../../db/prisma/prisma.client';
+import { roleMiddleware } from '../middleware/role.middleware';
+
+export const ofertaRoutes = Router();
+
+const OfertaBaseSchema = z.object({
+  productoId: z.coerce.number().int().positive(),
+  precioOferta: z.coerce.number().positive(),
+  fechaInicio: z.coerce.date(),
+  fechaFin: z.coerce.date(),
+  activo: z.boolean().optional().default(true),
+}).refine((data) => data.fechaFin > data.fechaInicio, {
+  message: 'fechaFin debe ser posterior a fechaInicio',
+  path: ['fechaFin'],
+});
+
+const CrearOfertaSchema = OfertaBaseSchema;
+
+const ActualizarOfertaSchema = z.object({
+  productoId: z.coerce.number().int().positive().optional(),
+  precioOferta: z.coerce.number().positive().optional(),
+  fechaInicio: z.coerce.date().optional(),
+  fechaFin: z.coerce.date().optional(),
+  activo: z.boolean().optional(),
+}).refine((data) => {
+  if (!data.fechaInicio || !data.fechaFin) return true;
+  return data.fechaFin > data.fechaInicio;
+}, {
+  message: 'fechaFin debe ser posterior a fechaInicio',
+  path: ['fechaFin'],
+});
+
+const ListarOfertasSchema = z.object({
+  productoId: z.coerce.number().int().positive().optional(),
+  activo: z.enum(['true', 'false']).optional(),
+  vigentes: z.enum(['true', 'false']).optional(),
+  take: z.coerce.number().int().positive().max(200).optional().default(100),
+});
+
+ofertaRoutes.get(
+  '/',
+  roleMiddleware('ADMIN'),
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const parsed = ListarOfertasSchema.safeParse(req.query);
+      if (!parsed.success) {
+        return res.status(400).json({
+          error: 'Parametros invalidos',
+          detalle: parsed.error.flatten().fieldErrors,
+        });
+      }
+
+      const { productoId, activo, vigentes, take } = parsed.data;
+      const ahora = new Date();
+
+      const ofertas = await prisma.oferta.findMany({
+        where: {
+          ...(productoId ? { productoId } : {}),
+          ...(activo !== undefined ? { activo: activo === 'true' } : {}),
+          ...(vigentes === 'true' ? {
+            activo: true,
+            fechaInicio: { lte: ahora },
+            fechaFin: { gte: ahora },
+          } : {}),
+        },
+        include: {
+          producto: {
+            select: {
+              id: true,
+              nombre: true,
+              precioVenta: true,
+              precioConIva: true,
+            },
+          },
+        },
+        orderBy: { creadoEn: 'desc' },
+        take,
+      });
+
+      return res.json({ total: ofertas.length, ofertas });
+    } catch (error) {
+      return next(error);
+    }
+  },
+);
+
+ofertaRoutes.post(
+  '/',
+  roleMiddleware('ADMIN'),
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const parsed = CrearOfertaSchema.safeParse(req.body);
+      if (!parsed.success) {
+        return res.status(400).json({
+          error: 'Datos de oferta invalidos',
+          detalle: parsed.error.flatten().fieldErrors,
+        });
+      }
+
+      const { productoId, precioOferta, fechaInicio, fechaFin, activo } = parsed.data;
+      const producto = await prisma.producto.findFirst({
+        where: { id: productoId, activo: true },
+        select: { id: true, nombre: true, precioVenta: true, precioConIva: true },
+      });
+
+      if (!producto) return res.status(404).json({ error: 'Producto no encontrado' });
+
+      const precioOriginal = obtenerPrecioOriginal(producto);
+      if (precioOferta >= precioOriginal) {
+        return res.status(400).json({ error: 'El precio de oferta debe ser menor al precio original' });
+      }
+
+      if (activo) {
+        const ofertaActiva = await prisma.oferta.findFirst({
+          where: { productoId, activo: true },
+          select: { id: true },
+        });
+
+        if (ofertaActiva) {
+          return res.status(409).json({ error: 'El producto ya tiene una oferta activa' });
+        }
+      }
+
+      const oferta = await prisma.oferta.create({
+        data: { productoId, precioOferta, fechaInicio, fechaFin, activo },
+        include: { producto: { select: { id: true, nombre: true, precioVenta: true, precioConIva: true } } },
+      });
+
+      return res.status(201).json({ mensaje: 'Oferta creada', oferta });
+    } catch (error) {
+      return next(error);
+    }
+  },
+);
+
+ofertaRoutes.patch(
+  '/:id',
+  roleMiddleware('ADMIN'),
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const id = Number(req.params.id);
+      if (!Number.isInteger(id) || id < 1) return res.status(400).json({ error: 'id invalido' });
+
+      const parsed = ActualizarOfertaSchema.safeParse(req.body);
+      if (!parsed.success) {
+        return res.status(400).json({
+          error: 'Datos de oferta invalidos',
+          detalle: parsed.error.flatten().fieldErrors,
+        });
+      }
+
+      const actual = await prisma.oferta.findUnique({
+        where: { id },
+        include: { producto: { select: { id: true, nombre: true, precioVenta: true, precioConIva: true } } },
+      });
+
+      if (!actual) return res.status(404).json({ error: 'Oferta no encontrada' });
+
+      const productoId = parsed.data.productoId ?? actual.productoId;
+      const producto = parsed.data.productoId
+        ? await prisma.producto.findFirst({
+            where: { id: productoId, activo: true },
+            select: { id: true, nombre: true, precioVenta: true, precioConIva: true },
+          })
+        : actual.producto;
+
+      if (!producto) return res.status(404).json({ error: 'Producto no encontrado' });
+
+      const precioOferta = parsed.data.precioOferta ?? actual.precioOferta;
+      const precioOriginal = obtenerPrecioOriginal(producto);
+      if (precioOferta >= precioOriginal) {
+        return res.status(400).json({ error: 'El precio de oferta debe ser menor al precio original' });
+      }
+
+      const activoNuevo = parsed.data.activo ?? actual.activo;
+      if (activoNuevo) {
+        const ofertaActiva = await prisma.oferta.findFirst({
+          where: { productoId, activo: true, id: { not: id } },
+          select: { id: true },
+        });
+
+        if (ofertaActiva) {
+          return res.status(409).json({ error: 'El producto ya tiene una oferta activa' });
+        }
+      }
+
+      const fechaInicio = parsed.data.fechaInicio ?? actual.fechaInicio;
+      const fechaFin = parsed.data.fechaFin ?? actual.fechaFin;
+      if (fechaFin <= fechaInicio) {
+        return res.status(400).json({ error: 'fechaFin debe ser posterior a fechaInicio' });
+      }
+
+      const oferta = await prisma.oferta.update({
+        where: { id },
+        data: {
+          ...(parsed.data.productoId !== undefined ? { productoId: parsed.data.productoId } : {}),
+          ...(parsed.data.precioOferta !== undefined ? { precioOferta: parsed.data.precioOferta } : {}),
+          ...(parsed.data.fechaInicio !== undefined ? { fechaInicio: parsed.data.fechaInicio } : {}),
+          ...(parsed.data.fechaFin !== undefined ? { fechaFin: parsed.data.fechaFin } : {}),
+          ...(parsed.data.activo !== undefined ? { activo: parsed.data.activo } : {}),
+        },
+        include: { producto: { select: { id: true, nombre: true, precioVenta: true, precioConIva: true } } },
+      });
+
+      return res.json({ mensaje: 'Oferta actualizada', oferta });
+    } catch (error) {
+      return next(error);
+    }
+  },
+);
+
+ofertaRoutes.delete(
+  '/:id',
+  roleMiddleware('ADMIN'),
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const id = Number(req.params.id);
+      if (!Number.isInteger(id) || id < 1) return res.status(400).json({ error: 'id invalido' });
+
+      const oferta = await prisma.oferta.update({
+        where: { id },
+        data: { activo: false },
+      });
+
+      return res.json({ mensaje: 'Oferta desactivada', oferta });
+    } catch (error: unknown) {
+      const e = error as { code?: string };
+      if (e.code === 'P2025') return res.status(404).json({ error: 'Oferta no encontrada' });
+      return next(error);
+    }
+  },
+);
+
+function obtenerPrecioOriginal(producto: { precioConIva: number | null; precioVenta: number | null }) {
+  return Number(producto.precioConIva ?? producto.precioVenta ?? 0);
+}

--- a/apps/server/src/adapters/http/routes/pedidos-online.routes.ts
+++ b/apps/server/src/adapters/http/routes/pedidos-online.routes.ts
@@ -182,6 +182,7 @@ productosPublicosRoutes.get('/publico/:sucursalId', async (req: Request, res: Re
       return res.status(400).json({ error: 'sucursalId invalido' });
     }
 
+    const ahora = new Date();
     const productos = await prisma.producto.findMany({
       where: {
         activo: true,
@@ -200,6 +201,21 @@ productosPublicosRoutes.get('/publico/:sucursalId', async (req: Request, res: Re
         precioVenta: true,
         precioConIva: true,
         categoria: { select: { id: true, nombre: true } },
+        ofertas: {
+          where: {
+            activo: true,
+            fechaInicio: { lte: ahora },
+            fechaFin: { gte: ahora },
+          },
+          select: {
+            id: true,
+            precioOferta: true,
+            fechaInicio: true,
+            fechaFin: true,
+          },
+          orderBy: { fechaInicio: 'desc' },
+          take: 1,
+        },
         stocks: {
           where: { sucursalId },
           select: {
@@ -215,6 +231,7 @@ productosPublicosRoutes.get('/publico/:sucursalId', async (req: Request, res: Re
     return res.json(productos.map((producto) => {
       const stock = producto.stocks[0];
       const disponible = Math.max(0, (stock?.cantidad ?? 0) - (stock?.stockReservado ?? 0));
+      const oferta = producto.ofertas[0] ?? null;
 
       return {
         id: producto.id,
@@ -223,6 +240,8 @@ productosPublicosRoutes.get('/publico/:sucursalId', async (req: Request, res: Re
         tipoUnidad: producto.tipoUnidad,
         precioVenta: producto.precioVenta,
         precioConIva: producto.precioConIva,
+        precioOferta: oferta?.precioOferta ?? null,
+        oferta,
         categoria: producto.categoria,
         sucursalId,
         stockDisponible: disponible,

--- a/apps/server/src/adapters/http/routes/webhook.routes.ts
+++ b/apps/server/src/adapters/http/routes/webhook.routes.ts
@@ -1,12 +1,12 @@
 // T-19.3: Webhook de Stripe — recibe payment_intent.succeeded / payment_intent.payment_failed.
 // Montado ANTES de express.json() en index.ts para que el body llegue sin parsear.
 import { Router, Request, Response } from 'express';
-import type Stripe from 'stripe';
 import { prisma }                    from '../../db/prisma/prisma.client';
 import { stripe, construirEventoStripe } from '../../payment/payment.service';
 import { enviarEmailConfirmacionPago } from '../../email/email.service';
 
 export const stripeWebhookRoutes = Router();
+type PaymentIntent = Awaited<ReturnType<typeof stripe.paymentIntents.create>>;
 
 stripeWebhookRoutes.post('/', async (req: Request, res: Response) => {
   const signature = req.headers['stripe-signature'];
@@ -23,7 +23,7 @@ stripeWebhookRoutes.post('/', async (req: Request, res: Response) => {
   }
 
   try {
-    const pi = evento.data.object as Stripe.PaymentIntent;
+    const pi = evento.data.object as PaymentIntent;
     if (evento.type === 'payment_intent.succeeded') {
       await manejarPagoExitoso(pi);
     } else if (evento.type === 'payment_intent.payment_failed') {
@@ -38,7 +38,7 @@ stripeWebhookRoutes.post('/', async (req: Request, res: Response) => {
   return res.json({ received: true });
 });
 
-async function manejarPagoExitoso(pi: Stripe.PaymentIntent): Promise<void> {
+async function manejarPagoExitoso(pi: PaymentIntent): Promise<void> {
   const pedidoId = Number(pi.metadata?.pedidoId);
   if (!pedidoId) return;
 
@@ -90,7 +90,7 @@ async function manejarPagoExitoso(pi: Stripe.PaymentIntent): Promise<void> {
   }
 }
 
-async function manejarPagoFallido(pi: Stripe.PaymentIntent): Promise<void> {
+async function manejarPagoFallido(pi: PaymentIntent): Promise<void> {
   const pedidoId = Number(pi.metadata?.pedidoId);
   if (!pedidoId) return;
 

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -13,6 +13,7 @@ import { ecommerceAuthRoutes } from './adapters/http/routes/ecommerce-auth.route
 import { usuarioRoutes }    from './adapters/http/routes/usuario.routes';
 import { categoriaRoutes }  from './adapters/http/routes/categoria.routes';
 import { productoRoutes }   from './adapters/http/routes/producto.routes';
+import { ofertaRoutes }     from './adapters/http/routes/oferta.routes';
 import { inventarioRoutes } from './adapters/http/routes/inventario.routes';
 import { ventasRoutes }     from './adapters/http/routes/ventas.routes';
 import { dteRoutes }        from './adapters/http/routes/dte.routes';
@@ -103,6 +104,7 @@ app.get('/sync/pendientes-local', (_req, res) => res.json(contarPendientes()));
 app.use('/api/usuarios',   usuarioRoutes);
 app.use('/api/categorias', categoriaRoutes);
 app.use('/api/productos',  productoRoutes);
+app.use('/api/ofertas',    ofertaRoutes);
 app.use('/api/inventario', inventarioRoutes);
 app.use('/api/ventas',     ventasRoutes);
 app.use('/api/caja',        cajaRoutes);


### PR DESCRIPTION
## Resumen

Implementa las tareas T-23.2 y T-23.3 del backlog HU-23 para ofertas digitales en ecommerce.

## Cambios realizados

- Agrega endpoint admin `POST /api/ofertas` para crear ofertas por producto.
- Agrega endpoints admin para listar, actualizar y desactivar ofertas.
- Valida que solo usuarios `ADMIN` puedan gestionar ofertas.
- Valida que no exista otra oferta activa para el mismo producto.
- Retorna `409` cuando el producto ya tiene una oferta activa.
- Valida fechas de vigencia y que `precioOferta` sea menor al precio original.
- Actualiza `GET /api/productos/publico/:sucursalId` para incluir:
  - `precioOferta`
  - `oferta`
- La oferta pública se calcula en backend según `activo`, `fechaInicio` y `fechaFin`.

## Validación

- `pnpm --filter server build` OK.
- Prueba manual de login admin OK.
- Prueba manual de creación de oferta OK.
- Prueba manual de duplicado activo retornó `409`.
- Prueba manual del catálogo público retornó `precioOferta` y datos de oferta vigente.
- Se desactivó la oferta usada en la prueba para no dejar datos temporales.