### PR TITLE
Feature/HU-25 kardex inventario

### DIFF
--- a/apps/server/src/adapters/http/routes/inventario.routes.ts
+++ b/apps/server/src/adapters/http/routes/inventario.routes.ts
@@ -331,6 +331,8 @@ inventarioRoutes.post(
         return res.status(400).json({ error: 'Origen y destino deben ser diferentes' });
       }
 
+      const usuarioId = req.usuario?.id ?? null;
+
       const [stockOrigen, stockDestino] = await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
         const origen = await tx.stockSucursal.findUnique({
           where: { productoId_sucursalId: { productoId, sucursalId: origenId } },
@@ -339,6 +341,12 @@ inventarioRoutes.post(
         if (!origen || origen.cantidad < cantidad) {
           throw new Error(`Stock insuficiente en sucursal origen. Disponible: ${origen?.cantidad ?? 0}`);
         }
+
+        // T-25.4: leer saldo destino antes del upsert para el kardex
+        const destinoActual = await tx.stockSucursal.findUnique({
+          where: { productoId_sucursalId: { productoId, sucursalId: destinoId } },
+        });
+        const saldoDestinoAntes = destinoActual?.cantidad ?? 0;
 
         const stockOrigen = await tx.stockSucursal.update({
           where: { productoId_sucursalId: { productoId, sucursalId: origenId } },
@@ -349,6 +357,33 @@ inventarioRoutes.post(
           where:  { productoId_sucursalId: { productoId, sucursalId: destinoId } },
           create: { productoId, sucursalId: destinoId, cantidad, minimo: 0 },
           update: { cantidad: { increment: cantidad } },
+        });
+
+        // T-25.4: movimiento SALIDA en origen y ENTRADA en destino — ambos o ninguno
+        await tx.movimientoInventario.create({
+          data: {
+            productoId,
+            sucursalId:   origenId,
+            tipo:         'TRANSFERENCIA_SALIDA',
+            cantidad,
+            saldoAnterior: origen.cantidad,
+            saldoNuevo:    origen.cantidad - cantidad,
+            referencia:   `TRANSFERENCIA-${origenId}-${destinoId}`,
+            usuarioId,
+          },
+        });
+
+        await tx.movimientoInventario.create({
+          data: {
+            productoId,
+            sucursalId:   destinoId,
+            tipo:         'TRANSFERENCIA_ENTRADA',
+            cantidad,
+            saldoAnterior: saldoDestinoAntes,
+            saldoNuevo:    saldoDestinoAntes + cantidad,
+            referencia:   `TRANSFERENCIA-${origenId}-${destinoId}`,
+            usuarioId,
+          },
         });
 
         return [stockOrigen, stockDestino];

--- a/apps/server/src/adapters/http/routes/pedidos-online.routes.ts
+++ b/apps/server/src/adapters/http/routes/pedidos-online.routes.ts
@@ -107,6 +107,7 @@ async function actualizarReservaPorEstado(
   tx: Prisma.TransactionClient,
   pedido: PedidoCompleto,
   estadoNuevo: EstadoPedidoOnline,
+  usuarioId?: number | null,
 ): Promise<void> {
   if (estadoNuevo !== 'CANCELADO' && estadoNuevo !== 'ENTREGADO') return;
 
@@ -118,6 +119,15 @@ async function actualizarReservaPorEstado(
   for (const detalle of detalles) {
     if (!Number.isInteger(detalle.cantidad) || detalle.cantidad <= 0) {
       throw new PedidoOnlineServiceError('El detalle del pedido tiene una cantidad invalida para inventario', 409);
+    }
+
+    // T-25.4: leer saldo antes de la actualización para el kardex (solo ENTREGADO descuenta stock)
+    let saldoAnterior = 0;
+    if (estadoNuevo === 'ENTREGADO') {
+      const stockActual = await tx.stockSucursal.findUnique({
+        where: { productoId_sucursalId: { productoId: detalle.productoId, sucursalId: pedido.sucursalId } },
+      });
+      saldoAnterior = stockActual?.cantidad ?? 0;
     }
 
     const resultado = estadoNuevo === 'CANCELADO'
@@ -151,6 +161,22 @@ async function actualizarReservaPorEstado(
           : 'No se pudo descontar el stock reservado del pedido',
         409,
       );
+    }
+
+    // T-25.4: registrar MovimientoInventario SALIDA_PEDIDO al confirmar entrega
+    if (estadoNuevo === 'ENTREGADO') {
+      await tx.movimientoInventario.create({
+        data: {
+          productoId:   detalle.productoId,
+          sucursalId:   pedido.sucursalId,
+          tipo:         'SALIDA_PEDIDO',
+          cantidad:     detalle.cantidad,
+          saldoAnterior,
+          saldoNuevo:   saldoAnterior - detalle.cantidad,
+          referencia:   `PEDIDO-${pedido.id}`,
+          usuarioId:    usuarioId ?? null,
+        },
+      });
     }
   }
 }
@@ -391,7 +417,7 @@ pedidosOnlineRoutes.patch(
         }
 
         if (estadoActual !== estadoNuevo) {
-          await actualizarReservaPorEstado(tx, actual, estadoNuevo);
+          await actualizarReservaPorEstado(tx, actual, estadoNuevo, req.usuario?.id);
         }
 
         return tx.pedidoOnline.update({

--- a/apps/server/src/adapters/http/routes/proveedor.routes.ts
+++ b/apps/server/src/adapters/http/routes/proveedor.routes.ts
@@ -162,11 +162,30 @@ proveedorRoutes.post(
           })),
         });
 
+        // T-25.3: upsert stock y registrar MovimientoInventario ENTRADA en la misma tx
         for (const item of items) {
+          const stockActual = await tx.stockSucursal.findUnique({
+            where: { productoId_sucursalId: { productoId: item.productoId, sucursalId } },
+          });
+          const saldoAnterior = stockActual?.cantidad ?? 0;
+
           await tx.stockSucursal.upsert({
             where:  { productoId_sucursalId: { productoId: item.productoId, sucursalId } },
             create: { productoId: item.productoId, sucursalId, cantidad: item.cantidad, minimo: 0 },
             update: { cantidad: { increment: item.cantidad } },
+          });
+
+          await tx.movimientoInventario.create({
+            data: {
+              productoId:   item.productoId,
+              sucursalId,
+              tipo:         'ENTRADA',
+              cantidad:     item.cantidad,
+              saldoAnterior,
+              saldoNuevo:   saldoAnterior + item.cantidad,
+              referencia:   `RECEPCION-${nueva.id}`,
+              usuarioId:    usuarioId ?? null,
+            },
           });
         }
 

--- a/apps/server/src/adapters/http/routes/ventas.routes.ts
+++ b/apps/server/src/adapters/http/routes/ventas.routes.ts
@@ -114,7 +114,9 @@ ventasRoutes.post('/', roleMiddleware('ADMIN', 'CAJERO'), async (req: Request, r
 
     const factura = await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
       // Verificar stock DENTRO de la transacción para evitar race conditions
+      // T-25.2: guardar saldoAnterior por productoId para los movimientos de kardex
       const erroresStock: string[] = [];
+      const saldosAnteriores = new Map<number, number>();
       for (const item of items) {
         const stock = await tx.stockSucursal.findUnique({
           where: { productoId_sucursalId: { productoId: item.productoId, sucursalId } },
@@ -125,6 +127,8 @@ ventasRoutes.post('/', roleMiddleware('ADMIN', 'CAJERO'), async (req: Request, r
             `"${nombre}" no tiene stock suficiente en esta sucursal. ` +
             `Disponible: ${stock?.cantidad ?? 0}, solicitado: ${item.cantidad}`
           );
+        } else {
+          saldosAnteriores.set(item.productoId, stock.cantidad);
         }
       }
       if (erroresStock.length > 0) {
@@ -155,6 +159,7 @@ ventasRoutes.post('/', roleMiddleware('ADMIN', 'CAJERO'), async (req: Request, r
         })),
       });
 
+      // T-25.2: decrementar stock y registrar MovimientoInventario SALIDA_VENTA en la misma tx
       for (const item of items) {
         await tx.stockSucursal.update({
           where: {
@@ -164,6 +169,20 @@ ventasRoutes.post('/', roleMiddleware('ADMIN', 'CAJERO'), async (req: Request, r
             },
           },
           data: { cantidad: { decrement: item.cantidad } },
+        });
+
+        const saldoAnterior = saldosAnteriores.get(item.productoId) ?? 0;
+        await tx.movimientoInventario.create({
+          data: {
+            productoId:      item.productoId,
+            sucursalId,
+            tipo:            'SALIDA_VENTA',
+            cantidad:        item.cantidad,
+            saldoAnterior,
+            saldoNuevo:      saldoAnterior - item.cantidad,
+            referencia:      `FACTURA-${nuevaFactura.id}`,
+            usuarioId:       usuarioId ?? null,
+          },
         });
       }
 


### PR DESCRIPTION
T-25.2 — [ventas.routes.ts]

En el bucle de chequeo de stock se guarda el saldoAnterior de cada producto en un Map.
Después de cada stockSucursal.update (decrement), se crea un MovimientoInventario tipo SALIDA_VENTA con referencia: FACTURA-{id}. Todo en la misma transacción → si el movimiento falla, la venta hace rollback completo.

T-25.3 — [proveedor.routes.ts]
Antes de cada stockSucursal.upsert se lee el stock actual (puede ser 0 si no existía).
Después del upsert se crea MovimientoInventario tipo ENTRADA con referencia: RECEPCION-{id}. Mismo patrón transaccional.

T-25.4 — [inventario.routes.ts]
Transferencia: se leen saldos de origen y destino antes de modificarlos, luego se crean TRANSFERENCIA_SALIDA y TRANSFERENCIA_ENTRADA en la misma transacción — un movimiento no puede existir sin el otro.
Pedido ENTREGADO: actualizarReservaPorEstado ahora recibe usuarioId, lee el saldo antes del updateMany, y crea SALIDA_PEDIDO con referencia: PEDIDO-{id} cuando el estado transiciona a ENTREGADO.