### PR TITLE
Feature/hu 24 gastos operativos

### DIFF
--- a/apps/renderer/src/components/layout/BottomNav.tsx
+++ b/apps/renderer/src/components/layout/BottomNav.tsx
@@ -20,6 +20,7 @@ const ALL_ITEMS: NavItem[] = [
   { label: 'Ventas',     to: '/ventas',     icon: <IcoSales      size={22} />, roles: ['ADMIN', 'CAJERO'] },
   { label: 'Devoluciones', to: '/devoluciones', icon: <IcoReports size={22} />, roles: ['ADMIN', 'CAJERO'] },
   { label: 'Caja',       to: '/caja',       icon: <IcoCaja       size={22} />, roles: ['ADMIN', 'CAJERO'] },
+  { label: 'Gastos',     to: '/gastos',     icon: <IcoReports    size={22} />, roles: ['ADMIN'] },
   { label: 'Usuarios',   to: '/usuarios',   icon: <IcoUsers      size={22} />, roles: ['ADMIN'] },
   { label: 'Categorias', to: '/categorias', icon: <IcoCategories size={22} />, roles: ['ADMIN'] },
   { label: 'Ofertas',    to: '/ofertas',    icon: <IcoReports    size={22} />, roles: ['ADMIN'] },

--- a/apps/renderer/src/components/layout/Sidebar.tsx
+++ b/apps/renderer/src/components/layout/Sidebar.tsx
@@ -26,6 +26,7 @@ const NAV_ITEMS: NavItem[] = [
   { label: 'Ventas',        to: '/ventas',        icon: <IcoSales />,       roles: ['ADMIN', 'CAJERO'] },
   { label: 'Devoluciones',  to: '/devoluciones',  icon: <IcoReports />,     roles: ['ADMIN', 'CAJERO'] },
   { label: 'Caja',           to: '/caja',           icon: <IcoCaja />,       roles: ['ADMIN', 'CAJERO'] },
+  { label: 'Gastos',        to: '/gastos',        icon: <IcoReports />,     roles: ['ADMIN'] },
   { label: 'Categorias',    to: '/categorias',    icon: <IcoCategories />,  roles: ['ADMIN'] },
   { label: 'Ofertas',       to: '/ofertas',       icon: <IcoReports />,     roles: ['ADMIN'] },
   { label: 'Usuarios',      to: '/usuarios',      icon: <IcoUsers />,       roles: ['ADMIN'] },

--- a/apps/renderer/src/pages/expenses/ExpensesPage.css
+++ b/apps/renderer/src/pages/expenses/ExpensesPage.css
@@ -1,0 +1,457 @@
+.expenses-page {
+  --expenses-panel: #060b1b;
+  --expenses-panel-2: #0b1226;
+  --expenses-panel-3: #111a2f;
+  --expenses-header: #202b40;
+  --expenses-input: #202b40;
+  --expenses-border: rgba(117, 137, 178, 0.22);
+  --expenses-muted: #8d98ad;
+  --expenses-row: #080f21;
+  --expenses-blue: #2293f6;
+  --expenses-green: #13ba68;
+  --expenses-orange: #b76511;
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+  min-height: 100%;
+  color: var(--text-primary);
+  animation: fadeUp 0.24s ease;
+}
+
+.expenses-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 18px;
+}
+
+.expenses-header h1 {
+  margin: 0;
+  font-size: 30px;
+  line-height: 1;
+  font-weight: 900;
+  letter-spacing: 0;
+  color: var(--text-primary);
+}
+
+.expenses-header p {
+  margin: 8px 0 0;
+  font-size: 13px;
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.expenses-alert {
+  border: 1px solid rgba(239, 68, 68, 0.26);
+  background: rgba(239, 68, 68, 0.08);
+  color: #fca5a5;
+  border-radius: 6px;
+  padding: 12px 14px;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.expenses-filters {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(130px, 1fr)) minmax(150px, auto);
+  gap: 18px;
+  align-items: end;
+  padding: 24px;
+  border-radius: 4px;
+  background: var(--expenses-panel);
+}
+
+.expenses-field {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-width: 0;
+}
+
+.expenses-label {
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--text-muted);
+  font-weight: 900;
+}
+
+.expenses-input,
+.expenses-select {
+  height: 38px;
+  width: 100%;
+  border: 1px solid var(--expenses-border);
+  border-radius: 5px;
+  background: var(--expenses-input);
+  color: var(--text-primary);
+  font: inherit;
+  font-size: 12px;
+  outline: none;
+  padding: 0 12px;
+}
+
+.expenses-select {
+  appearance: none;
+  background-image: linear-gradient(45deg, transparent 50%, var(--text-muted) 50%), linear-gradient(135deg, var(--text-muted) 50%, transparent 50%);
+  background-position: calc(100% - 16px) 16px, calc(100% - 11px) 16px;
+  background-size: 5px 5px, 5px 5px;
+  background-repeat: no-repeat;
+  padding-right: 34px;
+}
+
+.expenses-input::placeholder {
+  color: color-mix(in srgb, var(--text-muted) 70%, transparent);
+}
+
+.expenses-button {
+  height: 38px;
+  border: none;
+  border-radius: 5px;
+  background: var(--expenses-blue);
+  color: #fff;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.expenses-button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.expenses-button--success {
+  height: 30px;
+  padding: 0 14px;
+  border-radius: 5px;
+  background: #12a957;
+  font-size: 10px;
+}
+
+.expenses-button--wide {
+  width: 100%;
+  margin-top: 4px;
+}
+
+.expenses-stats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(180px, 1fr));
+  gap: 24px;
+}
+
+.expenses-stat {
+  min-height: 94px;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 12px;
+  padding: 18px 20px;
+  border-radius: 4px;
+  background: var(--expenses-panel-2);
+  border-bottom: 3px solid var(--expenses-muted);
+}
+
+.expenses-stat--blue {
+  border-bottom-color: var(--expenses-blue);
+}
+
+.expenses-stat--green {
+  border-bottom-color: var(--expenses-green);
+}
+
+.expenses-stat__label {
+  margin-bottom: 8px;
+  font-size: 9px;
+  letter-spacing: 0.12em;
+  font-weight: 900;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.expenses-stat__value {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.expenses-stat__value strong {
+  font-size: 30px;
+  line-height: 1;
+  font-weight: 900;
+  color: var(--text-primary);
+}
+
+.expenses-stat__value span {
+  font-size: 11px;
+  color: var(--text-muted);
+  font-weight: 600;
+}
+
+.expenses-stat__icon {
+  width: 38px;
+  height: 38px;
+  border-radius: 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: color-mix(in srgb, var(--expenses-blue) 22%, transparent);
+  color: var(--expenses-blue);
+  font-weight: 900;
+}
+
+.expenses-stat--green .expenses-stat__icon {
+  background: color-mix(in srgb, var(--expenses-green) 20%, transparent);
+  color: var(--expenses-green);
+}
+
+.expenses-workspace {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 280px;
+  gap: 28px;
+  align-items: start;
+}
+
+.expenses-card {
+  border-radius: 4px;
+  background: var(--expenses-panel);
+  overflow: hidden;
+}
+
+.expenses-card--form {
+  padding: 22px;
+}
+
+.expenses-section-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 18px 20px;
+}
+
+.expenses-section-title h2,
+.expenses-form-title {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 900;
+  letter-spacing: 0;
+  color: var(--text-primary);
+}
+
+.expenses-table-wrap {
+  overflow-x: auto;
+}
+
+.expenses-table {
+  width: 100%;
+  min-width: 700px;
+  border-collapse: collapse;
+}
+
+.expenses-table th {
+  background: var(--expenses-header);
+  padding: 13px 20px;
+  color: var(--text-muted);
+  font-size: 9px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  text-align: left;
+}
+
+.expenses-table td {
+  padding: 18px 20px;
+  border-top: 1px solid var(--expenses-border);
+  color: var(--text-primary);
+  font-size: 12px;
+  vertical-align: middle;
+}
+
+.expenses-table td:nth-child(3) {
+  color: var(--text-muted);
+  line-height: 1.35;
+}
+
+.expenses-table td:last-child {
+  text-align: right;
+  font-weight: 900;
+  white-space: nowrap;
+}
+
+.expenses-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 66px;
+  height: 18px;
+  padding: 0 10px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--expenses-blue) 22%, transparent);
+  color: #58adff;
+  font-size: 8px;
+  font-weight: 900;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.expenses-chip--green {
+  background: color-mix(in srgb, var(--expenses-green) 20%, transparent);
+  color: #60dd99;
+}
+
+.expenses-chip--purple {
+  background: rgba(147, 96, 255, 0.18);
+  color: #bf9bff;
+}
+
+.expenses-chip--orange {
+  background: rgba(217, 119, 6, 0.2);
+  color: #ffb15c;
+}
+
+.expenses-empty {
+  text-align: center !important;
+  padding: 30px 20px !important;
+  color: var(--text-muted) !important;
+}
+
+.expenses-table-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 20px 18px;
+  border-top: 1px solid var(--expenses-border);
+}
+
+.expenses-footnote {
+  font-size: 9px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  font-weight: 900;
+}
+
+.expenses-pagination {
+  display: flex;
+  gap: 8px;
+}
+
+.expenses-pagination button {
+  height: 28px;
+  border: none;
+  border-radius: 5px;
+  padding: 0 12px;
+  background: #344156;
+  color: var(--text-primary);
+  font: inherit;
+  font-size: 11px;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.expenses-pagination button:disabled {
+  opacity: 0.52;
+  cursor: not-allowed;
+}
+
+.expenses-form {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  margin-top: 20px;
+}
+
+.expenses-form-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+.expenses-help {
+  margin: 4px 0 0;
+  font-size: 10px;
+  color: var(--text-muted);
+}
+
+.theme-light .expenses-page {
+  --expenses-panel: #ffffff;
+  --expenses-panel-2: #ffffff;
+  --expenses-panel-3: #f6f3ed;
+  --expenses-header: #f4f1eb;
+  --expenses-input: #e2e0dc;
+  --expenses-border: #eee5d8;
+  --expenses-muted: #8c7d6a;
+  --expenses-row: #ffffff;
+  --expenses-blue: #a05b00;
+  --expenses-green: #19b965;
+  --expenses-orange: #a05b00;
+}
+
+.theme-light .expenses-filters {
+  background: #fff;
+  box-shadow: 0 1px 0 rgba(40, 32, 20, 0.03);
+}
+
+.theme-light .expenses-button {
+  background: #a05b00;
+}
+
+.theme-light .expenses-button--success {
+  background: #15944f;
+}
+
+.theme-light .expenses-input,
+.theme-light .expenses-select {
+  color: #3c3328;
+}
+
+.theme-light .expenses-card,
+.theme-light .expenses-stat {
+  border: 1px solid #eee5d8;
+}
+
+.theme-light .expenses-table td:nth-child(3),
+.theme-light .expenses-header p,
+.theme-light .expenses-help {
+  color: #817363;
+}
+
+.theme-light .expenses-pagination button {
+  background: #e2ddd6;
+  color: #5f5345;
+}
+
+@media (max-width: 1180px) {
+  .expenses-filters {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .expenses-filter-action {
+    grid-column: 1 / -1;
+  }
+
+  .expenses-workspace {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 760px) {
+  .expenses-header,
+  .expenses-section-title,
+  .expenses-table-footer {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .expenses-stats,
+  .expenses-filters,
+  .expenses-form-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .expenses-header h1 {
+    font-size: 25px;
+  }
+}

--- a/apps/renderer/src/pages/expenses/ExpensesPage.tsx
+++ b/apps/renderer/src/pages/expenses/ExpensesPage.tsx
@@ -1,0 +1,391 @@
+import { FormEvent, useCallback, useEffect, useMemo, useState } from 'react';
+import { api, isOfflineError } from '../../services/api.client';
+import { useAuthStore } from '../../store/authStore';
+import { generateExpensesExcel } from '../xlsxExporter/generateExpensesExcel';
+import './ExpensesPage.css';
+
+interface TipoGasto {
+  id: number;
+  nombre: string;
+  descripcion: string | null;
+}
+
+interface SucursalOption {
+  id: number;
+  nombre: string;
+}
+
+interface GastoItem {
+  id: number;
+  tipoGastoId: number;
+  monto: number;
+  descripcion: string | null;
+  fecha: string;
+  tipoGasto: { id: number; nombre: string };
+  sucursal: { id: number; nombre: string };
+  usuario: { id: number; nombre: string };
+}
+
+interface GastosResponse {
+  total: number;
+  totalMonto: number;
+  totalesPorTipo: Array<{ tipoGastoId: number; tipoGasto: string; total: number; cantidad: number }>;
+  gastos: GastoItem[];
+}
+
+interface BranchesResponseItem {
+  sucursalId: number;
+  sucursalNombre: string;
+}
+
+const ALL = '';
+const PAGE_SIZE = 6;
+const TIPO_GASTO_ORDER = ['Servicios', 'Sueldos', 'Transporte', 'Mantenimiento', 'Otros'];
+
+function todayInputValue() {
+  const date = new Date();
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function monthStartInputValue() {
+  const date = new Date();
+  date.setDate(1);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  return `${year}-${month}-01`;
+}
+
+function formatCurrency(value: number) {
+  return new Intl.NumberFormat('es-SV', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+function formatDate(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return new Intl.DateTimeFormat('es-SV', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    timeZone: 'UTC',
+  }).format(date);
+}
+
+function chipClass(index: number) {
+  return ['expenses-chip', 'expenses-chip expenses-chip--green', 'expenses-chip expenses-chip--purple', 'expenses-chip expenses-chip--orange'][index % 4];
+}
+
+function sortTiposGasto(tipos: TipoGasto[]) {
+  return [...tipos].sort((a, b) => {
+    const aIndex = TIPO_GASTO_ORDER.indexOf(a.nombre);
+    const bIndex = TIPO_GASTO_ORDER.indexOf(b.nombre);
+    const safeA = aIndex === -1 ? TIPO_GASTO_ORDER.length : aIndex;
+    const safeB = bIndex === -1 ? TIPO_GASTO_ORDER.length : bIndex;
+    return safeA === safeB ? a.nombre.localeCompare(b.nombre, 'es') : safeA - safeB;
+  });
+}
+
+export default function ExpensesPage() {
+  const { usuario } = useAuthStore();
+  const [tipos, setTipos] = useState<TipoGasto[]>([]);
+  const [sucursales, setSucursales] = useState<SucursalOption[]>([]);
+  const [response, setResponse] = useState<GastosResponse>({ total: 0, totalMonto: 0, totalesPorTipo: [], gastos: [] });
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [page, setPage] = useState(1);
+
+  const [filters, setFilters] = useState({
+    fechaInicio: monthStartInputValue(),
+    fechaFin: todayInputValue(),
+    tipoGastoId: ALL,
+    sucursalId: usuario?.sucursalId ? String(usuario.sucursalId) : ALL,
+  });
+  const [draftFilters, setDraftFilters] = useState(filters);
+
+  const [form, setForm] = useState({
+    tipoGastoId: '',
+    monto: '',
+    descripcion: '',
+    fecha: todayInputValue(),
+    sucursalId: usuario?.sucursalId ? String(usuario.sucursalId) : '',
+  });
+
+  const tipoNombre = useMemo(() => {
+    const map = new Map<number, string>();
+    tipos.forEach((tipo) => map.set(tipo.id, tipo.nombre));
+    return map;
+  }, [tipos]);
+
+  const sucursalNombre = useMemo(() => {
+    const map = new Map<number, string>();
+    sucursales.forEach((sucursal) => map.set(sucursal.id, sucursal.nombre));
+    return map;
+  }, [sucursales]);
+
+  const selectedBranchLabel = filters.sucursalId ? sucursalNombre.get(Number(filters.sucursalId)) ?? 'Sucursal' : 'Todas';
+  const topCategory = response.totalesPorTipo.reduce<
+    { tipoGastoId: number; tipoGasto: string; total: number; cantidad: number } | null
+  >((current, item) => (!current || item.total > current.total ? item : current), null);
+
+  const totalPages = Math.max(1, Math.ceil(response.gastos.length / PAGE_SIZE));
+  const safePage = Math.min(page, totalPages);
+  const visibleRows = response.gastos.slice((safePage - 1) * PAGE_SIZE, safePage * PAGE_SIZE);
+  const pageStart = response.gastos.length === 0 ? 0 : (safePage - 1) * PAGE_SIZE + 1;
+  const pageEnd = Math.min(safePage * PAGE_SIZE, response.gastos.length);
+
+  const loadOptions = useCallback(async () => {
+    const [tiposRes, sucursalesRes] = await Promise.all([
+      api.get<TipoGasto[]>('/tipos-gasto'),
+      api.get<BranchesResponseItem[]>('/inventario/criticos-por-sucursal'),
+    ]);
+
+    const branchOptions = sucursalesRes.data.map((item) => ({
+      id: item.sucursalId,
+      nombre: item.sucursalNombre,
+    }));
+
+    const sortedTipos = sortTiposGasto(tiposRes.data);
+
+    setTipos(sortedTipos);
+    setSucursales(branchOptions);
+
+    if (!form.sucursalId && branchOptions[0]) {
+      setForm((prev) => ({ ...prev, sucursalId: String(branchOptions[0].id) }));
+    }
+  }, [form.sucursalId]);
+
+  const loadGastos = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const params: Record<string, string> = { limit: '500' };
+    if (filters.fechaInicio) params.fechaInicio = filters.fechaInicio;
+    if (filters.fechaFin) params.fechaFin = filters.fechaFin;
+    if (filters.tipoGastoId) params.tipoGastoId = filters.tipoGastoId;
+    if (filters.sucursalId) params.sucursalId = filters.sucursalId;
+
+    try {
+      const { data } = await api.get<GastosResponse>('/gastos', { params });
+      setResponse(data);
+    } catch (err) {
+      setResponse({ total: 0, totalMonto: 0, totalesPorTipo: [], gastos: [] });
+      setError(isOfflineError(err) ? 'Sin conexion. No se pudieron cargar los gastos.' : 'Error al cargar gastos operativos.');
+    } finally {
+      setLoading(false);
+    }
+  }, [filters.fechaFin, filters.fechaInicio, filters.sucursalId, filters.tipoGastoId]);
+
+  useEffect(() => {
+    void loadOptions().catch(() => setError('No se pudieron cargar los catalogos de gastos.'));
+  }, [loadOptions]);
+
+  useEffect(() => {
+    void loadGastos();
+  }, [loadGastos]);
+
+  useEffect(() => {
+    setPage(1);
+  }, [filters]);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!form.tipoGastoId || !form.sucursalId) {
+      setError('Selecciona tipo de gasto y sucursal.');
+      return;
+    }
+    if (Number(form.monto) <= 0) {
+      setError('El monto debe ser mayor a 0.');
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+    try {
+      await api.post('/gastos', {
+        tipoGastoId: Number(form.tipoGastoId),
+        monto: Number(form.monto),
+        descripcion: form.descripcion.trim() || null,
+        fecha: form.fecha,
+        sucursalId: Number(form.sucursalId),
+      });
+      setForm((prev) => ({ ...prev, monto: '', descripcion: '', fecha: todayInputValue() }));
+      await loadGastos();
+    } catch (err: any) {
+      setError(err?.response?.data?.error ?? 'No se pudo registrar el gasto.');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function handleExport() {
+    generateExpensesExcel({
+      gastos: response.gastos,
+      summary: {
+        totalGastos: response.totalMonto,
+        cantidadGastos: response.total,
+        gastosPorCategoria: response.totalesPorTipo,
+      },
+      filters: {
+        startDate: filters.fechaInicio,
+        endDate: filters.fechaFin,
+        branchName: filters.sucursalId ? sucursalNombre.get(Number(filters.sucursalId)) : 'Todas las sucursales',
+        typeName: filters.tipoGastoId ? tipoNombre.get(Number(filters.tipoGastoId)) : 'Todos los tipos',
+      },
+      generatedBy: usuario?.nombre ?? 'Usuario',
+    });
+  }
+
+  return (
+    <div className="expenses-page">
+      <section className="expenses-header">
+        <div>
+          <h1>Gastos Operativos</h1>
+          <p>Registro y control de egresos por sucursal.</p>
+        </div>
+      </section>
+
+      {error ? <div className="expenses-alert">{error}</div> : null}
+
+      <section className="expenses-filters">
+        <label className="expenses-field">
+          <span className="expenses-label">Fecha inicio</span>
+          <input className="expenses-input" type="date" value={draftFilters.fechaInicio} onChange={(e) => setDraftFilters((prev) => ({ ...prev, fechaInicio: e.target.value }))} />
+        </label>
+        <label className="expenses-field">
+          <span className="expenses-label">Fecha fin</span>
+          <input className="expenses-input" type="date" value={draftFilters.fechaFin} onChange={(e) => setDraftFilters((prev) => ({ ...prev, fechaFin: e.target.value }))} />
+        </label>
+        <label className="expenses-field">
+          <span className="expenses-label">Tipo de gasto</span>
+          <select className="expenses-select" value={draftFilters.tipoGastoId} onChange={(e) => setDraftFilters((prev) => ({ ...prev, tipoGastoId: e.target.value }))}>
+            <option value={ALL}>Todos</option>
+            {tipos.map((tipo) => <option key={tipo.id} value={tipo.id}>{tipo.nombre}</option>)}
+          </select>
+        </label>
+        <label className="expenses-field">
+          <span className="expenses-label">Sucursal</span>
+          <select className="expenses-select" value={draftFilters.sucursalId} onChange={(e) => setDraftFilters((prev) => ({ ...prev, sucursalId: e.target.value }))}>
+            <option value={ALL}>Todas</option>
+            {sucursales.map((sucursal) => <option key={sucursal.id} value={sucursal.id}>{sucursal.nombre}</option>)}
+          </select>
+        </label>
+        <button className="expenses-button expenses-filter-action" type="button" onClick={() => setFilters(draftFilters)}>
+          Filtrar
+        </button>
+      </section>
+
+      <section className="expenses-stats">
+        <article className="expenses-stat">
+          <div>
+            <div className="expenses-stat__label">Total del periodo</div>
+            <div className="expenses-stat__value"><strong>{loading ? '...' : formatCurrency(response.totalMonto)}</strong></div>
+          </div>
+          <div className="expenses-stat__icon">$</div>
+        </article>
+        <article className="expenses-stat expenses-stat--blue">
+          <div>
+            <div className="expenses-stat__label">Registros</div>
+            <div className="expenses-stat__value"><strong>{loading ? '...' : response.total}</strong><span>gastos</span></div>
+          </div>
+          <div className="expenses-stat__icon">#</div>
+        </article>
+        <article className="expenses-stat expenses-stat--green">
+          <div>
+            <div className="expenses-stat__label">{topCategory ? topCategory.tipoGasto : 'Sucursal'}</div>
+            <div className="expenses-stat__value">
+              <strong>{loading ? '...' : topCategory ? formatCurrency(topCategory.total) : selectedBranchLabel}</strong>
+            </div>
+          </div>
+          <div className="expenses-stat__icon">{topCategory ? 'T' : 'S'}</div>
+        </article>
+      </section>
+
+      <section className="expenses-workspace">
+        <article className="expenses-card">
+          <div className="expenses-section-title">
+            <h2>Listado de gastos</h2>
+            <button className="expenses-button expenses-button--success" type="button" onClick={handleExport} disabled={response.gastos.length === 0}>
+              Excel
+            </button>
+          </div>
+          <div className="expenses-table-wrap">
+            <table className="expenses-table">
+              <thead>
+                <tr>
+                  <th>Fecha</th>
+                  <th>Tipo</th>
+                  <th>Descripcion</th>
+                  <th>Sucursal</th>
+                  <th>Monto</th>
+                </tr>
+              </thead>
+              <tbody>
+                {loading ? (
+                  <tr><td colSpan={5} className="expenses-empty">Cargando gastos...</td></tr>
+                ) : visibleRows.length === 0 ? (
+                  <tr><td colSpan={5} className="expenses-empty">No hay gastos con los filtros actuales.</td></tr>
+                ) : visibleRows.map((gasto, index) => (
+                  <tr key={gasto.id}>
+                    <td>{formatDate(gasto.fecha)}</td>
+                    <td><span className={chipClass(index)}>{gasto.tipoGasto.nombre}</span></td>
+                    <td>{gasto.descripcion ?? 'Sin descripcion'}</td>
+                    <td>{gasto.sucursal.nombre}</td>
+                    <td>{formatCurrency(gasto.monto)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <div className="expenses-table-footer">
+            <div className="expenses-footnote">Mostrando {pageStart} de {pageEnd} registros</div>
+            <div className="expenses-pagination">
+              <button type="button" disabled={safePage === 1} onClick={() => setPage((prev) => Math.max(1, prev - 1))}>Anterior</button>
+              <button type="button" disabled={safePage === totalPages || response.gastos.length === 0} onClick={() => setPage((prev) => Math.min(totalPages, prev + 1))}>Siguiente</button>
+            </div>
+          </div>
+        </article>
+
+        <aside className="expenses-card expenses-card--form">
+          <h2 className="expenses-form-title">Registrar gasto</h2>
+          <form className="expenses-form" onSubmit={handleSubmit}>
+            <label className="expenses-field">
+              <span className="expenses-label">Tipo de gasto</span>
+              <select className="expenses-select" value={form.tipoGastoId} onChange={(e) => setForm((prev) => ({ ...prev, tipoGastoId: e.target.value }))}>
+                <option value="">Seleccionar tipo...</option>
+                {tipos.map((tipo) => <option key={tipo.id} value={tipo.id}>{tipo.nombre}</option>)}
+              </select>
+            </label>
+            <label className="expenses-field">
+              <span className="expenses-label">Monto $</span>
+              <input className="expenses-input" type="number" min="0.01" step="0.01" placeholder="$ 0.00" value={form.monto} onChange={(e) => setForm((prev) => ({ ...prev, monto: e.target.value }))} />
+            </label>
+            <label className="expenses-field">
+              <span className="expenses-label">Descripcion</span>
+              <input className="expenses-input" type="text" placeholder="Ej: Compra de insumos..." value={form.descripcion} onChange={(e) => setForm((prev) => ({ ...prev, descripcion: e.target.value }))} />
+            </label>
+            <div className="expenses-form-grid">
+              <label className="expenses-field">
+                <span className="expenses-label">Fecha</span>
+                <input className="expenses-input" type="date" value={form.fecha} onChange={(e) => setForm((prev) => ({ ...prev, fecha: e.target.value }))} />
+              </label>
+              <label className="expenses-field">
+                <span className="expenses-label">Sucursal</span>
+                <select className="expenses-select" value={form.sucursalId} onChange={(e) => setForm((prev) => ({ ...prev, sucursalId: e.target.value }))}>
+                  <option value="">Sucursal</option>
+                  {sucursales.map((sucursal) => <option key={sucursal.id} value={sucursal.id}>{sucursal.nombre}</option>)}
+                </select>
+              </label>
+            </div>
+            <button className="expenses-button expenses-button--wide" type="submit" disabled={saving}>{saving ? 'Guardando...' : 'Registrar'}</button>
+          </form>
+        </aside>
+      </section>
+    </div>
+  );
+}

--- a/apps/renderer/src/pages/reports/ReportsPage.css
+++ b/apps/renderer/src/pages/reports/ReportsPage.css
@@ -44,6 +44,35 @@
   border-color: rgba(239, 68, 68, 0.28);
 }
 
+.reports-tabs {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  width: fit-content;
+  padding: 4px;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--bg-surface) 86%, var(--bg-base) 14%);
+  border: 1px solid var(--border);
+}
+
+.reports-tab {
+  height: 34px;
+  min-width: 92px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted);
+  font: inherit;
+  font-size: 12px;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.reports-tab--active {
+  background: var(--accent);
+  color: #fff;
+}
+
 .reports-header__title {
   display: flex;
   align-items: center;
@@ -364,6 +393,61 @@
   min-width: 1080px;
   border-collapse: collapse;
   table-layout: fixed;
+}
+
+.reports-table--expenses {
+  min-width: 760px;
+}
+
+.reports-expense-chart {
+  display: grid;
+  gap: 14px;
+  padding: 18px;
+  border-bottom: 1px solid rgba(112, 131, 175, 0.2);
+}
+
+.reports-expense-bar {
+  display: grid;
+  grid-template-columns: minmax(120px, 180px) minmax(180px, 1fr) minmax(96px, auto);
+  align-items: center;
+  gap: 14px;
+}
+
+.reports-expense-bar__label {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.reports-expense-bar__label strong {
+  font-size: 12px;
+  color: var(--text-primary);
+}
+
+.reports-expense-bar__label span {
+  font-size: 10px;
+  color: var(--text-muted);
+}
+
+.reports-expense-bar__track {
+  height: 12px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--bg-elevated) 72%, #ffffff 28%);
+  overflow: hidden;
+}
+
+.reports-expense-bar__track span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--accent), #13ba68);
+}
+
+.reports-expense-bar__value {
+  text-align: right;
+  font-size: 12px;
+  font-weight: 900;
+  color: var(--text-primary);
 }
 
 .reports-table thead th {
@@ -738,6 +822,14 @@
   color: #857867;
 }
 
+.theme-light .reports-tabs {
+  background: #f6f1e9;
+}
+
+.theme-light .reports-expense-bar__track {
+  background: #ebe4d8;
+}
+
 @media (max-width: 1120px) {
   .reports-stats {
     grid-template-columns: 1fr;
@@ -785,5 +877,13 @@
 
   .reports-pagination {
     flex-direction: column;
+  }
+
+  .reports-expense-bar {
+    grid-template-columns: 1fr;
+  }
+
+  .reports-expense-bar__value {
+    text-align: left;
   }
 }

--- a/apps/renderer/src/pages/reports/ReportsPage.tsx
+++ b/apps/renderer/src/pages/reports/ReportsPage.tsx
@@ -5,6 +5,7 @@ import { useThemeStore } from '../../store/themeStore';
 import { Modal } from '../../components/ui/Modal';
 import { exportSalesReportPdf } from '../pdf-exporter/sales-report-pdf';
 import { generateSalesExcel } from '../xlsxExporter/generateSalesExcel';
+import { generateExpensesExcel } from '../xlsxExporter/generateExpensesExcel';
 import './ReportsPage.css';
 
 interface BranchOption {
@@ -39,6 +40,24 @@ interface ReportesVentasResumen {
   cantidadVentas: number;
   promedioVenta: number;
   ventasPorDia: Array<{ fecha: string; total: number }>;
+}
+
+interface GastoReporte {
+  id: number;
+  fecha: string;
+  descripcion: string | null;
+  monto: number;
+  tipoGasto: { id: number; nombre: string };
+  sucursal: { id: number; nombre: string };
+  usuario?: { id: number; nombre: string };
+}
+
+interface ReportesGastosResumen {
+  totalGastos: number;
+  cantidadGastos: number;
+  gastosPorCategoria: Array<{ tipoGastoId: number; tipoGasto: string; total: number; cantidad: number }>;
+  gastosPorDia: Array<{ fecha: string; total: number }>;
+  gastos: GastoReporte[];
 }
 
 interface BranchesResponseItem {
@@ -87,6 +106,17 @@ function formatCurrency(value: number) {
   }).format(value);
 }
 
+function formatExpenseDate(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return new Intl.DateTimeFormat('es-SV', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    timeZone: 'UTC',
+  }).format(date);
+}
+
 function buildResumen(items: ReportItem[]) {
   if (items.length === 0) return 'Sin productos';
   const names = items.slice(0, 2).map(item => item.producto);
@@ -101,11 +131,19 @@ export default function ReportsPage() {
   const isAdmin = usuario?.rol === 'ADMIN';
 
   const [ventas, setVentas] = useState<VentaReporte[]>([]);
+  const [activeTab, setActiveTab] = useState<'ventas' | 'gastos'>('ventas');
   const [summary, setSummary] = useState<ReportesVentasResumen>({
     totalVentas: 0,
     cantidadVentas: 0,
     promedioVenta: 0,
     ventasPorDia: [],
+  });
+  const [gastosSummary, setGastosSummary] = useState<ReportesGastosResumen>({
+    totalGastos: 0,
+    cantidadGastos: 0,
+    gastosPorCategoria: [],
+    gastosPorDia: [],
+    gastos: [],
   });
   const [branchOptions, setBranchOptions] = useState<BranchOption[]>([]);
   const [loading, setLoading] = useState(true);
@@ -171,9 +209,12 @@ export default function ReportsPage() {
     if (appliedFilters.branchId) params.sucursalId = appliedFilters.branchId;
 
     try {
-      const [ventasRes, resumenRes] = await Promise.all([
+      const [ventasRes, resumenRes, gastosRes] = await Promise.all([
         api.get<{ total: number; ventas: VentaReporte[] }>('/reportes/ventas', { params }),
         api.get<ReportesVentasResumen>('/reportes/ventas/resumen', { params }),
+        isAdmin
+          ? api.get<ReportesGastosResumen>('/reportes/gastos', { params })
+          : Promise.resolve({ data: { totalGastos: 0, cantidadGastos: 0, gastosPorCategoria: [], gastosPorDia: [], gastos: [] } }),
       ]);
 
       setVentas(ventasRes.data.ventas ?? []);
@@ -185,6 +226,7 @@ export default function ReportsPage() {
           ventasPorDia: [],
         },
       );
+      setGastosSummary(gastosRes.data);
     } catch (err) {
       setVentas([]);
       setSummary({
@@ -193,6 +235,7 @@ export default function ReportsPage() {
         promedioVenta: 0,
         ventasPorDia: [],
       });
+      setGastosSummary({ totalGastos: 0, cantidadGastos: 0, gastosPorCategoria: [], gastosPorDia: [], gastos: [] });
       setLoadError(
         isOfflineError(err)
           ? 'Sin conexion. No se pudieron cargar los reportes de ventas.'
@@ -201,7 +244,7 @@ export default function ReportsPage() {
     } finally {
       setLoading(false);
     }
-  }, [appliedFilters.endDate, appliedFilters.branchId, appliedFilters.startDate]);
+  }, [appliedFilters.endDate, appliedFilters.branchId, appliedFilters.startDate, isAdmin]);
 
   useEffect(() => {
     void loadBranches();
@@ -266,6 +309,20 @@ export default function ReportsPage() {
     });
   }, [exportFilters, summary, ventas, visibleName]);
 
+  const maxGastoCategoria = useMemo(
+    () => Math.max(1, ...gastosSummary.gastosPorCategoria.map((item) => item.total)),
+    [gastosSummary.gastosPorCategoria],
+  );
+
+  const handleExportGastosExcel = useCallback(() => {
+    generateExpensesExcel({
+      gastos: gastosSummary.gastos,
+      summary: gastosSummary,
+      filters: exportFilters,
+      generatedBy: visibleName,
+    });
+  }, [exportFilters, gastosSummary, visibleName]);
+
   return (
     <div className="reports-page">
       <section className="reports-header">
@@ -296,6 +353,154 @@ export default function ReportsPage() {
 
       {loadError ? <div className="reports-alert reports-alert--error">{loadError}</div> : null}
 
+      <div className="reports-tabs" role="tablist" aria-label="Tipo de reporte">
+        <button
+          type="button"
+          className={activeTab === 'ventas' ? 'reports-tab reports-tab--active' : 'reports-tab'}
+          onClick={() => setActiveTab('ventas')}
+        >
+          Ventas
+        </button>
+        {isAdmin ? (
+          <button
+            type="button"
+            className={activeTab === 'gastos' ? 'reports-tab reports-tab--active' : 'reports-tab'}
+            onClick={() => setActiveTab('gastos')}
+          >
+            Gastos
+          </button>
+        ) : null}
+      </div>
+
+      {activeTab === 'gastos' ? (
+        <>
+          <section className="reports-stats">
+            <article className="reports-stat-card">
+              <div className="reports-stat-card__label">Gastos registrados</div>
+              <div className="reports-stat-card__value reports-stat-card__value--accent">
+                <strong>{loading ? '...' : formatNumber(gastosSummary.cantidadGastos)}</strong>
+              </div>
+            </article>
+
+            <article className="reports-stat-card">
+              <div className="reports-stat-card__label">Total gastos</div>
+              <div className="reports-stat-card__value">
+                <strong>{loading ? '...' : formatCurrency(gastosSummary.totalGastos)}</strong>
+              </div>
+            </article>
+
+            <article className="reports-stat-card">
+              <div className="reports-stat-card__label">Categorias</div>
+              <div className="reports-stat-card__value">
+                <strong>{loading ? '...' : formatNumber(gastosSummary.gastosPorCategoria.length)}</strong>
+              </div>
+            </article>
+          </section>
+
+          <section className="reports-filters">
+            <div className="reports-field-group">
+              <label className="reports-field-group__label">Rango de fechas</label>
+              <div className="reports-date-fields">
+                <input className="reports-input" type="date" value={startDate} onChange={(event) => setStartDate(event.target.value)} />
+                <input className="reports-input" type="date" value={endDate} onChange={(event) => setEndDate(event.target.value)} />
+              </div>
+            </div>
+
+            <div className="reports-field-group">
+              <label className="reports-field-group__label">Sucursal</label>
+              <div className="reports-select-wrap">
+                <select
+                  className="reports-select"
+                  value={branchFilter}
+                  disabled={!isAdmin && branchOptionsToRender.length <= 1}
+                  onChange={(event) => setBranchFilter(event.target.value)}
+                >
+                  <option value={ALL_BRANCHES}>Todas las sucursales</option>
+                  {branchOptionsToRender.map((branch) => (
+                    <option key={branch.id} value={String(branch.id)}>{branch.nombre}</option>
+                  ))}
+                </select>
+                <span className="reports-select-caret" aria-hidden="true">{'\u25BE'}</span>
+              </div>
+            </div>
+
+            <button
+              type="button"
+              className="reports-filter-button"
+              onClick={() => setAppliedFilters({ startDate, endDate, branchId: branchFilter })}
+            >
+              Filtrar gastos
+            </button>
+          </section>
+
+          <section className="reports-list-card">
+            <div className="reports-list-card__header">
+              <div>
+                <h2 className="reports-list-card__title">Gastos por categoria</h2>
+                <p style={{ marginTop: '4px', fontSize: '12px', color: 'var(--text-muted)' }}>
+                  Totales operativos filtrados por fecha y sucursal.
+                </p>
+              </div>
+              <button
+                type="button"
+                className="reports-export-button"
+                onClick={handleExportGastosExcel}
+                disabled={loading || gastosSummary.gastos.length === 0}
+              >
+                <span>{'\u2193'}</span>
+                Exportar Excel
+              </button>
+            </div>
+
+            <div className="reports-expense-chart">
+              {loading ? (
+                <div className="reports-empty-state">Cargando gastos...</div>
+              ) : gastosSummary.gastosPorCategoria.length === 0 ? (
+                <div className="reports-empty-state">No hay gastos con los filtros actuales.</div>
+              ) : gastosSummary.gastosPorCategoria.map((item) => (
+                <div key={item.tipoGastoId} className="reports-expense-bar">
+                  <div className="reports-expense-bar__label">
+                    <strong>{item.tipoGasto}</strong>
+                    <span>{item.cantidad} registros</span>
+                  </div>
+                  <div className="reports-expense-bar__track">
+                    <span style={{ width: `${Math.max(8, (item.total / maxGastoCategoria) * 100)}%` }} />
+                  </div>
+                  <div className="reports-expense-bar__value">{formatCurrency(item.total)}</div>
+                </div>
+              ))}
+            </div>
+
+            <div className="reports-table-wrap">
+              <table className="reports-table reports-table--expenses">
+                <thead>
+                  <tr>
+                    <th>Fecha</th>
+                    <th>Tipo</th>
+                    <th>Descripcion</th>
+                    <th>Sucursal</th>
+                    <th>Monto</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {gastosSummary.gastos.length === 0 ? (
+                    <tr><td colSpan={5} className="reports-empty-state">No hay gastos para mostrar.</td></tr>
+                  ) : gastosSummary.gastos.slice(0, 80).map((gasto) => (
+                    <tr key={gasto.id}>
+                      <td>{formatExpenseDate(gasto.fecha)}</td>
+                      <td><span className="reports-chip">{gasto.tipoGasto.nombre}</span></td>
+                      <td>{gasto.descripcion ?? 'Sin descripcion'}</td>
+                      <td>{gasto.sucursal.nombre}</td>
+                      <td className="reports-cell-qty">{formatCurrency(gasto.monto)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        </>
+      ) : (
+        <>
       <section className="reports-stats">
         <article className="reports-stat-card">
           <div className="reports-stat-card__label">Ventas registradas</div>
@@ -520,6 +725,8 @@ export default function ReportsPage() {
           </div>
         </div>
       </section>
+        </>
+      )}
 
       <Modal
         open={!!selectedVenta}

--- a/apps/renderer/src/pages/xlsxExporter/generateExpensesExcel.tsx
+++ b/apps/renderer/src/pages/xlsxExporter/generateExpensesExcel.tsx
@@ -1,0 +1,380 @@
+export interface ExpenseExcelItem {
+  id: number;
+  fecha: string;
+  descripcion: string | null;
+  monto: number;
+  tipoGasto: { id: number; nombre: string };
+  sucursal: { id: number; nombre: string };
+  usuario?: { id: number; nombre: string };
+}
+
+export interface ExpenseExcelSummary {
+  totalGastos: number;
+  cantidadGastos: number;
+  gastosPorCategoria: Array<{ tipoGastoId: number; tipoGasto: string; total: number; cantidad: number }>;
+  gastosPorDia?: Array<{ fecha: string; total: number }>;
+}
+
+interface GenerateExpensesExcelOptions {
+  gastos: ExpenseExcelItem[];
+  summary: ExpenseExcelSummary;
+  filters?: {
+    startDate?: string;
+    endDate?: string;
+    branchName?: string;
+    typeName?: string;
+  };
+  generatedBy?: string;
+}
+
+function escapeHtml(value: string | number | null | undefined) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function normalizeFilePart(value: string) {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '') || 'gastos';
+}
+
+function resolveRangeLabel(filters?: GenerateExpensesExcelOptions['filters']) {
+  if (!filters?.startDate && !filters?.endDate) return 'Todos los periodos';
+  if (filters.startDate && filters.endDate) return `${filters.startDate} a ${filters.endDate}`;
+  if (filters.startDate) return `Desde ${filters.startDate}`;
+  return `Hasta ${filters.endDate}`;
+}
+
+function formatDate(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value || 'N/D';
+  return new Intl.DateTimeFormat('es-SV', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    timeZone: 'UTC',
+  }).format(date);
+}
+
+function formatGeneratedAt() {
+  return new Intl.DateTimeFormat('es-SV', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(new Date());
+}
+
+function formatCurrency(value: number) {
+  return new Intl.NumberFormat('es-SV', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+function formatPercent(value: number) {
+  return new Intl.NumberFormat('es-SV', {
+    style: 'percent',
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1,
+  }).format(value);
+}
+
+function metricCard(title: string, value: string, accent: string) {
+  return `
+    <td colspan="2" style="background:#f7f9fc;border:1px solid #d6e0ee;border-top:5px solid ${accent};padding:14px 16px;">
+      <div style="color:#5c6b82;font-size:11px;font-weight:700;text-transform:uppercase;">${escapeHtml(title)}</div>
+      <div style="color:#0f172a;font-size:24px;font-weight:800;margin-top:8px;">${escapeHtml(value)}</div>
+    </td>
+  `;
+}
+
+function buildCategoryRows(options: GenerateExpensesExcelOptions) {
+  const rows = options.summary.gastosPorCategoria.length
+    ? options.summary.gastosPorCategoria
+    : [{ tipoGastoId: 0, tipoGasto: 'Sin datos', total: 0, cantidad: 0 }];
+
+  return rows.map((item) => {
+    const participation = options.summary.totalGastos > 0 ? item.total / options.summary.totalGastos : 0;
+    const average = item.cantidad > 0 ? item.total / item.cantidad : 0;
+
+    return `
+      <tr>
+        <td style="border:1px solid #d9e2ef;">${escapeHtml(item.tipoGasto)}</td>
+        <td style="border:1px solid #d9e2ef;text-align:right;font-weight:700;">${item.cantidad}</td>
+        <td style="border:1px solid #d9e2ef;text-align:right;font-weight:700;">${escapeHtml(formatCurrency(item.total))}</td>
+        <td style="border:1px solid #d9e2ef;text-align:right;font-weight:700;">${escapeHtml(formatPercent(participation))}</td>
+        <td style="border:1px solid #d9e2ef;text-align:right;font-weight:700;">${escapeHtml(formatCurrency(average))}</td>
+      </tr>
+    `;
+  }).join('');
+}
+
+function buildDailyRows(options: GenerateExpensesExcelOptions) {
+  const rows = options.summary.gastosPorDia?.length
+    ? options.summary.gastosPorDia
+    : [{ fecha: 'Sin datos', total: 0 }];
+
+  return rows.map((item) => `
+    <tr>
+      <td style="border:1px solid #d9e2ef;">${escapeHtml(item.fecha)}</td>
+      <td style="border:1px solid #d9e2ef;text-align:right;font-weight:700;">${escapeHtml(formatCurrency(item.total))}</td>
+    </tr>
+  `).join('');
+}
+
+function buildExpenseRows(options: GenerateExpensesExcelOptions) {
+  if (options.gastos.length === 0) {
+    return '<tr><td colspan="6" class="empty">Sin gastos para mostrar</td></tr>';
+  }
+
+  return options.gastos.map((gasto) => `
+    <tr>
+      <td style="border:1px solid #d9e2ef;">${escapeHtml(formatDate(gasto.fecha))}</td>
+      <td style="border:1px solid #d9e2ef;">${escapeHtml(gasto.tipoGasto.nombre)}</td>
+      <td style="border:1px solid #d9e2ef;">${escapeHtml(gasto.descripcion || 'Sin descripcion')}</td>
+      <td style="border:1px solid #d9e2ef;">${escapeHtml(gasto.sucursal.nombre)}</td>
+      <td style="border:1px solid #d9e2ef;">${escapeHtml(gasto.usuario?.nombre || 'N/D')}</td>
+      <td style="border:1px solid #d9e2ef;text-align:right;font-weight:700;">${escapeHtml(formatCurrency(gasto.monto))}</td>
+    </tr>
+  `).join('');
+}
+
+function buildWorkbookHtml(options: GenerateExpensesExcelOptions) {
+  const topCategory = options.summary.gastosPorCategoria[0];
+  const period = resolveRangeLabel(options.filters);
+  const branch = options.filters?.branchName || 'Todas las sucursales';
+  const type = options.filters?.typeName || 'Todos los tipos';
+
+  return `
+    <!doctype html>
+    <html>
+      <head>
+        <meta charset="utf-8" />
+        <style>
+          body {
+            font-family: Arial, Helvetica, sans-serif;
+            color: #172033;
+            background: #ffffff;
+          }
+
+          .sheet {
+            width: 980px;
+          }
+
+          .hero {
+            background: #0f2747;
+            color: #ffffff;
+            border-radius: 8px;
+          }
+
+          .hero-title {
+            font-size: 24px;
+            font-weight: 800;
+            letter-spacing: .5px;
+          }
+
+          .hero-subtitle {
+            color: #c7d7f2;
+            font-size: 12px;
+          }
+
+          .meta-label {
+            color: #6b7890;
+            font-weight: 700;
+            text-transform: uppercase;
+            font-size: 11px;
+            letter-spacing: .6px;
+          }
+
+          .meta-value {
+            color: #1f2937;
+            font-weight: 700;
+          }
+
+          .metric {
+            background: #f5f8fc;
+            border: 1px solid #dce5f2;
+            border-radius: 8px;
+            padding: 14px;
+          }
+
+          .metric-label {
+            color: #64748b;
+            font-size: 11px;
+            font-weight: 800;
+            text-transform: uppercase;
+            letter-spacing: .7px;
+          }
+
+          .metric-value {
+            color: #0f172a;
+            font-size: 24px;
+            font-weight: 800;
+            margin-top: 6px;
+          }
+
+          .section-title {
+            background: #eaf2ff;
+            color: #0f2747;
+            font-size: 15px;
+            font-weight: 800;
+            border-left: 6px solid #2563eb;
+          }
+
+          table {
+            border-collapse: collapse;
+          }
+
+          .data-table th {
+            background: #17365d;
+            color: #ffffff;
+            border: 1px solid #17365d;
+            font-weight: 800;
+            text-align: left;
+          }
+
+          .data-table td {
+            border: 1px solid #d9e2ef;
+          }
+
+          .data-table tr:nth-child(even) td {
+            background: #f8fafc;
+          }
+
+          .money,
+          .number {
+            text-align: right;
+            font-weight: 700;
+          }
+
+          .tag {
+            background: #dbeafe;
+            color: #1d4ed8;
+            font-weight: 800;
+            border-radius: 999px;
+            padding: 3px 10px;
+            text-transform: uppercase;
+            font-size: 10px;
+          }
+
+          .empty {
+            color: #64748b;
+            text-align: center;
+            font-style: italic;
+          }
+        </style>
+      </head>
+      <body>
+        <table class="sheet" cellpadding="7" cellspacing="0" style="width:980px;border-collapse:collapse;">
+          <colgroup>
+            <col style="width:155px;" />
+            <col style="width:185px;" />
+            <col style="width:155px;" />
+            <col style="width:185px;" />
+            <col style="width:155px;" />
+            <col style="width:145px;" />
+          </colgroup>
+          <tr>
+            <td colspan="6" style="background:#0f2747;color:#ffffff;padding:16px 18px;border:1px solid #0f2747;">
+              <div style="font-size:24px;font-weight:800;">FERRED - REPORTE DE GASTOS OPERATIVOS</div>
+              <div style="font-size:12px;color:#c7d7f2;margin-top:4px;">Control financiero por sucursal, categoria y periodo</div>
+            </td>
+          </tr>
+          <tr>
+            <td style="background:#f1f5f9;color:#526173;font-weight:700;border:1px solid #d6e0ee;">Generado por</td>
+            <td style="border:1px solid #d6e0ee;font-weight:700;">${escapeHtml(options.generatedBy || 'Usuario')}</td>
+            <td style="background:#f1f5f9;color:#526173;font-weight:700;border:1px solid #d6e0ee;">Fecha</td>
+            <td style="border:1px solid #d6e0ee;font-weight:700;">${escapeHtml(formatGeneratedAt())}</td>
+            <td style="background:#f1f5f9;color:#526173;font-weight:700;border:1px solid #d6e0ee;">Archivo</td>
+            <td style="border:1px solid #d6e0ee;font-weight:700;">Exportacion Excel</td>
+          </tr>
+          <tr>
+            <td style="background:#f1f5f9;color:#526173;font-weight:700;border:1px solid #d6e0ee;">Periodo</td>
+            <td style="border:1px solid #d6e0ee;font-weight:700;">${escapeHtml(period)}</td>
+            <td style="background:#f1f5f9;color:#526173;font-weight:700;border:1px solid #d6e0ee;">Sucursal</td>
+            <td style="border:1px solid #d6e0ee;font-weight:700;">${escapeHtml(branch)}</td>
+            <td style="background:#f1f5f9;color:#526173;font-weight:700;border:1px solid #d6e0ee;">Tipo</td>
+            <td style="border:1px solid #d6e0ee;font-weight:700;">${escapeHtml(type)}</td>
+          </tr>
+          <tr><td colspan="6" style="height:10px;"></td></tr>
+          <tr>
+            ${metricCard('Gastos registrados', String(options.summary.cantidadGastos), '#2563eb')}
+            ${metricCard('Total gastos', formatCurrency(options.summary.totalGastos), '#13ba68')}
+            ${metricCard('Categoria principal', topCategory ? `${topCategory.tipoGasto} - ${formatCurrency(topCategory.total)}` : 'Sin datos', '#7c3aed')}
+          </tr>
+          <tr><td colspan="6" style="height:12px;"></td></tr>
+          <tr><td colspan="6" style="background:#eaf2ff;color:#0f2747;font-weight:800;border-left:6px solid #2563eb;padding:8px 10px;">Distribucion por categoria</td></tr>
+        </table>
+
+        <table class="sheet data-table" cellpadding="8" cellspacing="0" style="width:980px;border-collapse:collapse;">
+          <thead>
+            <tr>
+              <th style="width:260px;background:#17365d;color:#ffffff;border:1px solid #17365d;text-align:left;">Categoria</th>
+              <th style="width:120px;background:#17365d;color:#ffffff;border:1px solid #17365d;text-align:right;">Cantidad</th>
+              <th style="width:140px;background:#17365d;color:#ffffff;border:1px solid #17365d;text-align:right;">Total</th>
+              <th style="width:140px;background:#17365d;color:#ffffff;border:1px solid #17365d;text-align:right;">Participacion</th>
+              <th style="width:140px;background:#17365d;color:#ffffff;border:1px solid #17365d;text-align:right;">Promedio</th>
+            </tr>
+          </thead>
+          <tbody>${buildCategoryRows(options)}</tbody>
+        </table>
+
+        <table class="sheet" cellpadding="0" cellspacing="0" style="width:980px;border-collapse:collapse;"><tr><td style="height:14px;"></td></tr></table>
+        <table class="sheet" cellpadding="8" cellspacing="0" style="width:980px;border-collapse:collapse;">
+          <tr><td colspan="2" style="background:#eaf2ff;color:#0f2747;font-weight:800;border-left:6px solid #13ba68;padding:8px 10px;">Totales por dia</td></tr>
+        </table>
+        <table class="sheet data-table" cellpadding="8" cellspacing="0" style="width:420px;border-collapse:collapse;">
+          <thead>
+            <tr>
+              <th style="width:220px;background:#17365d;color:#ffffff;border:1px solid #17365d;text-align:left;">Fecha</th>
+              <th style="width:160px;background:#17365d;color:#ffffff;border:1px solid #17365d;text-align:right;">Total del dia</th>
+            </tr>
+          </thead>
+          <tbody>${buildDailyRows(options)}</tbody>
+        </table>
+
+        <table class="sheet" cellpadding="0" cellspacing="0" style="width:980px;border-collapse:collapse;"><tr><td style="height:14px;"></td></tr></table>
+        <table class="sheet" cellpadding="8" cellspacing="0" style="width:980px;border-collapse:collapse;">
+          <tr><td colspan="6" style="background:#eaf2ff;color:#0f2747;font-weight:800;border-left:6px solid #7c3aed;padding:8px 10px;">Detalle de gastos</td></tr>
+        </table>
+        <table class="sheet data-table" cellpadding="8" cellspacing="0" style="width:980px;border-collapse:collapse;">
+          <thead>
+            <tr>
+              <th style="width:120px;background:#17365d;color:#ffffff;border:1px solid #17365d;text-align:left;">Fecha</th>
+              <th style="width:140px;background:#17365d;color:#ffffff;border:1px solid #17365d;text-align:left;">Tipo</th>
+              <th style="width:300px;background:#17365d;color:#ffffff;border:1px solid #17365d;text-align:left;">Descripcion</th>
+              <th style="width:180px;background:#17365d;color:#ffffff;border:1px solid #17365d;text-align:left;">Sucursal</th>
+              <th style="width:160px;background:#17365d;color:#ffffff;border:1px solid #17365d;text-align:left;">Usuario</th>
+              <th style="width:120px;background:#17365d;color:#ffffff;border:1px solid #17365d;text-align:right;">Monto</th>
+            </tr>
+          </thead>
+          <tbody>${buildExpenseRows(options)}</tbody>
+        </table>
+      </body>
+    </html>
+  `;
+}
+
+export function generateExpensesExcel(options: GenerateExpensesExcelOptions) {
+  const html = buildWorkbookHtml(options);
+  const blob = new Blob([html], { type: 'application/vnd.ms-excel;charset=utf-8' });
+  const range = normalizeFilePart(resolveRangeLabel(options.filters));
+  const fileName = `reporte-gastos-${range}.xls`;
+
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = fileName;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+}

--- a/apps/renderer/src/router/AppRouter.tsx
+++ b/apps/renderer/src/router/AppRouter.tsx
@@ -17,6 +17,7 @@ import TransfersPage       from '../pages/transfers/TransfersPage';
 import StockPage           from '../pages/stock/StockPage';
 import VentasPage          from '../pages/ventas/VentasPage';
 import ReportsPage         from '../pages/reports/ReportsPage';
+import ExpensesPage        from '../pages/expenses/ExpensesPage';
 import CajaPage from '../pages/caja/CajaPage';
 import CajaHistorialPage from '../pages/caja/historial/CajaHistorialPage';
 import PedidosOnlinePage   from '../pages/pedidos-online/PedidosOnlinePage';
@@ -60,6 +61,7 @@ export function AppRouter() {
           <Route path="usuarios"      element={<RoleGuard roles={['ADMIN']}><UsersPage /></RoleGuard>} />
           <Route path="categorias"    element={<RoleGuard roles={['ADMIN']}><CategoriesPage /></RoleGuard>} />
           <Route path="reportes"      element={<RoleGuard roles={['ADMIN', 'BODEGA']}><ReportsPage /></RoleGuard>} />
+          <Route path="gastos"        element={<RoleGuard roles={['ADMIN']}><ExpensesPage /></RoleGuard>} />
           <Route path="historial-recepciones" element={<RoleGuard roles={['ADMIN', 'BODEGA']}><ReceptionHistoryPage /></RoleGuard>} />
           <Route path="ajustes"       element={<RoleGuard roles={['ADMIN']}><AjustesPage /></RoleGuard>} />
           <Route path="transferencias" element={<RoleGuard roles={['ADMIN']}><TransfersPage /></RoleGuard>} />

--- a/apps/server/src/adapters/http/routes/gastos.routes.ts
+++ b/apps/server/src/adapters/http/routes/gastos.routes.ts
@@ -1,0 +1,283 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { z } from 'zod';
+import { prisma } from '../../db/prisma/prisma.client';
+import { roleMiddleware } from '../middleware/role.middleware';
+
+export const gastosRoutes = Router();
+export const tiposGastoRoutes = Router();
+
+gastosRoutes.use(roleMiddleware('ADMIN'));
+tiposGastoRoutes.use(roleMiddleware('ADMIN'));
+
+const GastoQuerySchema = z.object({
+  sucursalId: z.coerce.number().int().positive().optional(),
+  tipoGastoId: z.coerce.number().int().positive().optional(),
+  fechaInicio: z.string().date('fechaInicio debe ser YYYY-MM-DD').optional(),
+  fechaFin: z.string().date('fechaFin debe ser YYYY-MM-DD').optional(),
+  limit: z.coerce.number().int().min(1).max(500).optional().default(200),
+});
+
+const GastoSchema = z.object({
+  tipoGastoId: z.coerce.number().int().positive(),
+  monto: z.coerce.number().positive('El monto debe ser mayor a 0'),
+  descripcion: z.string().max(255).optional().nullable(),
+  fecha: z.coerce.date().optional(),
+  sucursalId: z.coerce.number().int().positive(),
+});
+
+const TipoGastoSchema = z.object({
+  nombre: z.string().trim().min(2).max(80),
+  descripcion: z.string().max(255).optional().nullable(),
+});
+
+type GastoQuery = z.infer<typeof GastoQuerySchema>;
+
+function parseFecha(valor: string | undefined, finDelDia = false): Date | undefined {
+  if (!valor) return undefined;
+  const fecha = new Date(valor);
+  if (finDelDia) fecha.setUTCHours(23, 59, 59, 999);
+  return fecha;
+}
+
+function buildGastosWhere(params: GastoQuery) {
+  return {
+    ...(params.sucursalId ? { sucursalId: params.sucursalId } : {}),
+    ...(params.tipoGastoId ? { tipoGastoId: params.tipoGastoId } : {}),
+    ...(params.fechaInicio || params.fechaFin
+      ? {
+          fecha: {
+            ...(params.fechaInicio ? { gte: parseFecha(params.fechaInicio) } : {}),
+            ...(params.fechaFin ? { lte: parseFecha(params.fechaFin, true) } : {}),
+          },
+        }
+      : {}),
+  };
+}
+
+function redondearMonto(valor: number) {
+  return Number(valor.toFixed(2));
+}
+
+gastosRoutes.get('/', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const parsed = GastoQuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      return res.status(400).json({
+        error: 'Parametros invalidos',
+        detalle: parsed.error.flatten().fieldErrors,
+      });
+    }
+
+    const where = buildGastosWhere(parsed.data);
+    const gastos = await prisma.gasto.findMany({
+      where,
+      include: {
+        tipoGasto: { select: { id: true, nombre: true } },
+        sucursal: { select: { id: true, nombre: true } },
+        usuario: { select: { id: true, nombre: true } },
+      },
+      orderBy: { fecha: 'desc' },
+      take: parsed.data.limit,
+    });
+
+    const totalMonto = redondearMonto(gastos.reduce((acc, gasto) => acc + gasto.monto, 0));
+    const porTipo = new Map<number, { tipoGastoId: number; tipoGasto: string; total: number; cantidad: number }>();
+
+    for (const gasto of gastos) {
+      const actual = porTipo.get(gasto.tipoGastoId) ?? {
+        tipoGastoId: gasto.tipoGastoId,
+        tipoGasto: gasto.tipoGasto.nombre,
+        total: 0,
+        cantidad: 0,
+      };
+      actual.total += gasto.monto;
+      actual.cantidad += 1;
+      porTipo.set(gasto.tipoGastoId, actual);
+    }
+
+    return res.json({
+      total: gastos.length,
+      totalMonto,
+      totalesPorTipo: Array.from(porTipo.values()).map((item) => ({
+        ...item,
+        total: redondearMonto(item.total),
+      })),
+      gastos,
+    });
+  } catch (error) {
+    return next(error);
+  }
+});
+
+gastosRoutes.post('/', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const parsed = GastoSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({
+        error: 'Datos de gasto invalidos',
+        detalle: parsed.error.flatten().fieldErrors,
+      });
+    }
+
+    const { tipoGastoId, sucursalId } = parsed.data;
+    const [tipoGasto, sucursal] = await Promise.all([
+      prisma.tipoGasto.findUnique({ where: { id: tipoGastoId }, select: { id: true } }),
+      prisma.sucursal.findUnique({ where: { id: sucursalId }, select: { id: true } }),
+    ]);
+
+    if (!tipoGasto) return res.status(404).json({ error: 'Tipo de gasto no encontrado' });
+    if (!sucursal) return res.status(404).json({ error: 'Sucursal no encontrada' });
+    if (!req.usuario?.id) return res.status(401).json({ error: 'Usuario no autenticado' });
+
+    const gasto = await prisma.gasto.create({
+      data: {
+        tipoGastoId,
+        sucursalId,
+        usuarioId: req.usuario.id,
+        monto: parsed.data.monto,
+        descripcion: parsed.data.descripcion ?? null,
+        fecha: parsed.data.fecha ?? new Date(),
+      },
+      include: {
+        tipoGasto: { select: { id: true, nombre: true } },
+        sucursal: { select: { id: true, nombre: true } },
+        usuario: { select: { id: true, nombre: true } },
+      },
+    });
+
+    return res.status(201).json({ mensaje: 'Gasto registrado', gasto });
+  } catch (error) {
+    return next(error);
+  }
+});
+
+gastosRoutes.patch('/:id', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const id = Number(req.params.id);
+    if (!Number.isInteger(id) || id < 1) return res.status(400).json({ error: 'id invalido' });
+
+    const parsed = GastoSchema.partial().safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({
+        error: 'Datos de gasto invalidos',
+        detalle: parsed.error.flatten().fieldErrors,
+      });
+    }
+
+    if (parsed.data.tipoGastoId) {
+      const tipoGasto = await prisma.tipoGasto.findUnique({
+        where: { id: parsed.data.tipoGastoId },
+        select: { id: true },
+      });
+      if (!tipoGasto) return res.status(404).json({ error: 'Tipo de gasto no encontrado' });
+    }
+
+    if (parsed.data.sucursalId) {
+      const sucursal = await prisma.sucursal.findUnique({
+        where: { id: parsed.data.sucursalId },
+        select: { id: true },
+      });
+      if (!sucursal) return res.status(404).json({ error: 'Sucursal no encontrada' });
+    }
+
+    const gasto = await prisma.gasto.update({
+      where: { id },
+      data: parsed.data,
+      include: {
+        tipoGasto: { select: { id: true, nombre: true } },
+        sucursal: { select: { id: true, nombre: true } },
+        usuario: { select: { id: true, nombre: true } },
+      },
+    });
+
+    return res.json({ mensaje: 'Gasto actualizado', gasto });
+  } catch (error: unknown) {
+    const e = error as { code?: string };
+    if (e.code === 'P2025') return res.status(404).json({ error: 'Gasto no encontrado' });
+    return next(error);
+  }
+});
+
+gastosRoutes.delete('/:id', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const id = Number(req.params.id);
+    if (!Number.isInteger(id) || id < 1) return res.status(400).json({ error: 'id invalido' });
+
+    await prisma.gasto.delete({ where: { id } });
+    return res.json({ mensaje: 'Gasto eliminado' });
+  } catch (error: unknown) {
+    const e = error as { code?: string };
+    if (e.code === 'P2025') return res.status(404).json({ error: 'Gasto no encontrado' });
+    return next(error);
+  }
+});
+
+tiposGastoRoutes.get('/', async (_req: Request, res: Response, next: NextFunction) => {
+  try {
+    const tipos = await prisma.tipoGasto.findMany({ orderBy: { nombre: 'asc' } });
+    return res.json(tipos);
+  } catch (error) {
+    return next(error);
+  }
+});
+
+tiposGastoRoutes.post('/', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const parsed = TipoGastoSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({
+        error: 'Datos de tipo de gasto invalidos',
+        detalle: parsed.error.flatten().fieldErrors,
+      });
+    }
+
+    const tipo = await prisma.tipoGasto.create({ data: parsed.data });
+    return res.status(201).json({ mensaje: 'Tipo de gasto creado', tipo });
+  } catch (error: unknown) {
+    const e = error as { code?: string };
+    if (e.code === 'P2002') return res.status(409).json({ error: 'Ya existe un tipo de gasto con ese nombre' });
+    return next(error);
+  }
+});
+
+tiposGastoRoutes.patch('/:id', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const id = Number(req.params.id);
+    if (!Number.isInteger(id) || id < 1) return res.status(400).json({ error: 'id invalido' });
+
+    const parsed = TipoGastoSchema.partial().safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({
+        error: 'Datos de tipo de gasto invalidos',
+        detalle: parsed.error.flatten().fieldErrors,
+      });
+    }
+
+    const tipo = await prisma.tipoGasto.update({ where: { id }, data: parsed.data });
+    return res.json({ mensaje: 'Tipo de gasto actualizado', tipo });
+  } catch (error: unknown) {
+    const e = error as { code?: string };
+    if (e.code === 'P2025') return res.status(404).json({ error: 'Tipo de gasto no encontrado' });
+    if (e.code === 'P2002') return res.status(409).json({ error: 'Ya existe un tipo de gasto con ese nombre' });
+    return next(error);
+  }
+});
+
+tiposGastoRoutes.delete('/:id', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const id = Number(req.params.id);
+    if (!Number.isInteger(id) || id < 1) return res.status(400).json({ error: 'id invalido' });
+
+    const gastosAsociados = await prisma.gasto.count({ where: { tipoGastoId: id } });
+    if (gastosAsociados > 0) {
+      return res.status(409).json({ error: 'No se puede eliminar un tipo de gasto con gastos asociados' });
+    }
+
+    await prisma.tipoGasto.delete({ where: { id } });
+    return res.json({ mensaje: 'Tipo de gasto eliminado' });
+  } catch (error: unknown) {
+    const e = error as { code?: string };
+    if (e.code === 'P2025') return res.status(404).json({ error: 'Tipo de gasto no encontrado' });
+    return next(error);
+  }
+});

--- a/apps/server/src/adapters/http/routes/reportes.routes.ts
+++ b/apps/server/src/adapters/http/routes/reportes.routes.ts
@@ -59,6 +59,32 @@ function buildWhere(
   };
 }
 
+const ReporteGastosQuerySchema = z.object({
+  fechaInicio: z.string().date('fechaInicio debe ser YYYY-MM-DD').optional(),
+  fechaFin:    z.string().date('fechaFin debe ser YYYY-MM-DD').optional(),
+  sucursalId:  z.coerce.number().int().positive().optional(),
+  tipoGastoId: z.coerce.number().int().positive().optional(),
+});
+
+function buildGastosWhere(params: z.infer<typeof ReporteGastosQuerySchema>) {
+  return {
+    ...(params.sucursalId ? { sucursalId: params.sucursalId } : {}),
+    ...(params.tipoGastoId ? { tipoGastoId: params.tipoGastoId } : {}),
+    ...(params.fechaInicio || params.fechaFin
+      ? {
+          fecha: {
+            ...(params.fechaInicio ? { gte: parseFecha(params.fechaInicio) } : {}),
+            ...(params.fechaFin ? { lte: parseFecha(params.fechaFin, true) } : {}),
+          },
+        }
+      : {}),
+  };
+}
+
+function redondearMonto(valor: number) {
+  return Number(valor.toFixed(2));
+}
+
 // ── T-05.1: GET /api/reportes/ventas ────────────────────────────
 // Lista de ventas (facturas) con detalles, filtrada por fecha/sucursal/cajero.
 reportesRoutes.get(
@@ -179,6 +205,79 @@ reportesRoutes.get(
         .map(([fecha, total]) => ({ fecha, total: Number(total.toFixed(2)) }));
 
       return res.json({ totalVentas, cantidadVentas, promedioVenta, ventasPorDia });
+    } catch (err) { return next(err); }
+  },
+);
+
+// ── T-24.3: GET /api/reportes/gastos ───────────────────────────────
+// Totales de gastos con los mismos filtros de fecha/sucursal para no tocar reportes de ventas.
+reportesRoutes.get(
+  '/gastos',
+  roleMiddleware('ADMIN'),
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const parsed = ReporteGastosQuerySchema.safeParse(req.query);
+      if (!parsed.success) {
+        return res.status(400).json({
+          error: 'Parametros invalidos',
+          detalle: parsed.error.flatten().fieldErrors,
+        });
+      }
+
+      const gastos = await prisma.gasto.findMany({
+        where: buildGastosWhere(parsed.data),
+        select: {
+          id: true,
+          monto: true,
+          descripcion: true,
+          fecha: true,
+          tipoGasto: { select: { id: true, nombre: true } },
+          sucursal: { select: { id: true, nombre: true } },
+          usuario: { select: { id: true, nombre: true } },
+        },
+        orderBy: { fecha: 'asc' },
+      });
+
+      const porCategoria = new Map<number, { tipoGastoId: number; tipoGasto: string; total: number; cantidad: number }>();
+      const porDia = new Map<string, number>();
+      let suma = 0;
+
+      for (const gasto of gastos) {
+        suma += gasto.monto;
+
+        const categoria = porCategoria.get(gasto.tipoGasto.id) ?? {
+          tipoGastoId: gasto.tipoGasto.id,
+          tipoGasto: gasto.tipoGasto.nombre,
+          total: 0,
+          cantidad: 0,
+        };
+        categoria.total += gasto.monto;
+        categoria.cantidad += 1;
+        porCategoria.set(gasto.tipoGasto.id, categoria);
+
+        const fecha = gasto.fecha.toISOString().slice(0, 10);
+        porDia.set(fecha, (porDia.get(fecha) ?? 0) + gasto.monto);
+      }
+
+      return res.json({
+        totalGastos: redondearMonto(suma),
+        cantidadGastos: gastos.length,
+        gastosPorCategoria: Array.from(porCategoria.values())
+          .map((item) => ({ ...item, total: redondearMonto(item.total) }))
+          .sort((a, b) => b.total - a.total),
+        gastosPorDia: Array.from(porDia.entries())
+          .sort(([a], [b]) => a.localeCompare(b))
+          .map(([fecha, total]) => ({ fecha, total: redondearMonto(total) })),
+        gastos: gastos.map((gasto) => ({
+          id: gasto.id,
+          fecha: gasto.fecha,
+          descripcion: gasto.descripcion,
+          monto: gasto.monto,
+          tipoGasto: gasto.tipoGasto,
+          sucursal: gasto.sucursal,
+          usuario: gasto.usuario,
+        })),
+      });
     } catch (err) { return next(err); }
   },
 );

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -19,6 +19,7 @@ import { ventasRoutes }     from './adapters/http/routes/ventas.routes';
 import { dteRoutes }        from './adapters/http/routes/dte.routes';
 import { proveedorRoutes }  from './adapters/http/routes/proveedor.routes';
 import { cajaRoutes } from './adapters/http/routes/caja.routes';
+import { gastosRoutes, tiposGastoRoutes } from './adapters/http/routes/gastos.routes';
 import { pagosRoutes }      from './adapters/http/routes/pagos.routes';
 import { pagosOnlineRoutes } from './adapters/http/routes/pagos-online.routes';
 import {
@@ -112,6 +113,8 @@ app.use('/api/ofertas',    ofertaRoutes);
 app.use('/api/inventario', inventarioRoutes);
 app.use('/api/ventas',     ventasRoutes);
 app.use('/api/caja',        cajaRoutes);
+app.use('/api/gastos',      gastosRoutes);
+app.use('/api/tipos-gasto', tiposGastoRoutes);
 app.use('/api/dte',        dteRoutes);
 app.use('/api/proveedores', proveedorRoutes);
 app.use('/api/sync',       syncRoutes);


### PR DESCRIPTION
## Resumen

Implementa HU-24: modulo de gastos operativos para administradores, incluyendo registro, consulta, reportes y exportacion.

## Cambios incluidos

- T-24.2 y T-24.3: agrega endpoints de gastos operativos y reporte agregado en backend.
- T-24.4: agrega pantalla de Gastos con formulario, filtros, tabla historica, totales y acceso solo ADMIN.
- T-24.5: agrega pestaña de Gastos en Reportes con grafico por categoria, tabla y exportacion Excel.

## Validacion

- `pnpm --filter server build`
- `pnpm --filter renderer build`

## Notas

- T-24.1 ya estaba cubierto por los modelos Prisma existentes.
- T-24.6 se documenta fuera del repo como evidencia QA.